### PR TITLE
Add docs deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to gh-pages
+name: Build site into docs
 on:
   push:
     branches: [main]
@@ -6,33 +6,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      # 1) جلب الكود
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      # 2) إعداد Node
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      # 3) تثبيت التبعيات
-      - name: Install deps
+      - name: Install dependencies
         run: npm ci
 
-      # 4) بناء موقع Astro
-      - name: Build site
+      - name: Astro build
         run: npx astro build --site https://tamermansour-ai.github.io/Tamer-Portfolio/
 
-      # 5) نشر مجلد dist إلى فرع gh-pages
-      - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist            # مجلد الخرج بعد build
-          publish_branch: gh-pages       # سينشئه إذا غير موجود
-          user_name: github-actions[bot] # هويّة الكوميت
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          force_orphan: true             # أنشئ تاريخ نظيف للفرع
+      - name: Copy dist → docs
+        run: |
+          rm -rf docs
+          cp -R dist docs
+
+      - name: Commit docs folder
+        run: |
+          git config --local user.name  "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs
+          git commit -m "Astro build -> docs" || echo "No changes"
+          git push origin main


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Astro site into `docs` folder on `main` branch

## Testing
- `git push origin main` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_6873e1648b6c83229d03c349f1e7c5d1