### PR TITLE
Expand portfolio structure with bilingual sections

### DIFF
--- a/docs/ar/index.html
+++ b/docs/ar/index.html
@@ -1,24 +1,71 @@
 <!DOCTYPE html><html lang="ar" dir="rtl">
-<head>
-  <meta charset="UTF-8" />
-  <title>تامر منصور – معرض أعمال</title>
-  <link rel="stylesheet" href="../style.css" />
-</head>
+<head><meta charset="UTF-8"><title>تامر منصور – معرض الأعمال</title>
+<link rel="stylesheet" href="../css/style.css"></head>
 <body class="bg-white text-zinc-900">
-  <header class="p-6 flex justify-between items-center max-w-5xl mx-auto">
-    <h1 class="text-xl font-bold text-[var(--olive)]">تامر منصور</h1>
-    <a href="../" class="underline text-sm">EN</a>
-  </header>
+<header class="max-w-6xl mx-auto flex justify-between items-center p-6">
+  <h1 class="text-xl font-bold text-[var(--olive)]">تامر منصور</h1>
+  <nav>
+    <a href="#about">عنّي</a><a href="#projects">المشاريع</a><a href="#media">المعرض</a><a href="#blog">مدوّنة</a><a href="#contact">تواصل</a>
+  </nav>
+  <button onclick="switchLang('en')" class="underline text-sm">EN</button>
+</header>
 
-  <section class="text-center py-20">
-    <div class="w-40 h-40 rounded-full mx-auto shadow mb-6 bg-zinc-200 flex items-center justify-center text-sm text-zinc-500">profile.jpg</div>
-    <h2 class="text-3xl font-bold mb-4">سِرْ في طريقي بالذكاء الاصطناعي — وافتح مستقبلك.</h2>
-    <p class="max-w-xl mx-auto mb-8">مزيج من إتقان أدوات الذكاء الاصطناعي ورؤية إبداعية ولمسة فلسطينية لإلهام المبتكرين القادمين.</p>
-    <a href="#follow" class="px-6 py-3 rounded-full bg-[var(--olive)] text-white hover:shadow-lg">تابع أعمالي</a>
-  </section>
+<!-- Hero -->
+<section id="hero" class="text-center">
+  <img src="../assets/profile.jpg" alt="profile" class="w-40 h-40 rounded-full mx-auto shadow mb-6" />
+  <h2 class="text-3xl font-bold mb-4">سِر في طريقي بالذكاء الاصطناعي — وافتح مستقبلك.</h2>
+  <p class="max-w-xl mx-auto mb-8">مزيج من إتقان أدوات الذكاء الاصطناعي ورؤية إبداعية وروح فلسطينية لإلهام المبتكرين القادمين.</p>
+  <a href="#follow" class="hero-btn">تابع أعمالي</a>
+</section>
 
-  <footer class="text-center py-6 text-sm bg-zinc-100">
-    © <span id="y"></span> تامر منصور — <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">راسلني</a>
-  </footer>
-  <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
+<!-- About -->
+<section id="about" class="max-w-4xl mx-auto">
+  <h3 class="text-2xl font-bold mb-4">نبذة</h3>
+  <p>أنا تامر، مستشار ذكاء اصطناعي وصانع أفلام فلسطيني ومبدع. أدمج التقنية بالفن لصنع تجارب مؤثرة ومساعدة الآخرين على الازدهار عبر الإبداع المدعوم بالذكاء الاصطناعي.</p>
+</section>
+
+<!-- Featured Projects -->
+<section id="projects" class="bg-zinc-100">
+  <h3 class="text-2xl font-bold text-center mb-6">المشاريع المميزة</h3>
+  <div class="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto">
+    <article class="border rounded p-4">
+      <h4 class="font-semibold mb-2">أطياف الأرض</h4>
+      <p class="text-sm mb-2">فيلم وثائقي مولَّد بالذكاء الاصطناعي يستكشف التراث الفلسطيني.</p>
+      <a href="../projects/atyaf.html" class="underline text-sm">المزيد</a>
+    </article>
+  </div>
+  <p class="text-center mt-6"><a href="../projects/ar/" class="underline">عرض كل المشاريع →</a></p>
+</section>
+
+<!-- AI Media Gallery -->
+<section id="media" class="max-w-6xl mx-auto">
+  <h3 class="text-2xl font-bold mb-6 text-center">معرض الوسائط بالذكاء الاصطناعي</h3>
+  <p class="text-center text-sm mb-4">صور · فيديو · موسيقى (تصفية قريباً)</p>
+  <div class="grid md:grid-cols-4 gap-4">
+    <div class="aspect-square bg-zinc-200 flex items-center justify-center text-xs">placeholder</div>
+  </div>
+</section>
+
+<!-- Blog / Insights teaser -->
+<section id="blog" class="bg-zinc-100">
+  <h3 class="text-2xl font-bold text-center mb-6">أحدث المقالات</h3>
+  <p class="text-center text-sm mb-4">قريباً — مقالات معمقة ودروس تعليمية.</p>
+</section>
+
+<!-- Services placeholder -->
+<section id="services" class="max-w-4xl mx-auto">
+  <h3 class="text-2xl font-bold mb-4">خدمات (قريباً)</h3>
+  <ul class="list-disc pl-6"><li>استشارات ذكاء اصطناعي</li><li>ورش عمل وتدريب</li><li>إخراج إبداعي</li></ul>
+</section>
+
+<!-- Contact -->
+<section id="contact" class="text-center pt-12">
+  <h3 class="text-2xl font-bold mb-4">تواصل معي</h3>
+  <p>البريد: <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">ai.visionary.pioneer@gmail.com</a></p>
+  <p>واتساب: +970 XXXX XXX</p>
+  <p class="mt-4 text-sm">© <span id="y"></span> تامر منصور</p>
+</section>
+
+<script src="../js/main.js"></script>
+<script>document.getElementById('y').textContent=new Date().getFullYear();</script>
 </body></html>

--- a/docs/assets/README.txt
+++ b/docs/assets/README.txt
@@ -1,1 +1,1 @@
-Put profile.jpg (400×400) and any other images here. GitHub Pages will serve /assets/* directly.
+Drop your images and video thumbnails here.

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,0 +1,3 @@
+# Blog Placeholder
+
+Future articles and tutorials will live here.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,0 +1,7 @@
+@import url("https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/dist/tailwind.min.css");
+:root{--olive:#556b2f;--gold:#cfaf3c;--off:#f7f7f5;}
+body{font-family:"Inter",sans-serif;scroll-behavior:smooth;}
+section{padding-block:4rem}
+.hero-btn{background:var(--olive);color:#fff;border-radius:9999px;padding:.8rem 2rem;transition:.2s;}
+.hero-btn:hover{box-shadow:0 0 10px var(--gold);} 
+nav a{margin-inline:.5rem}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,25 +1,74 @@
 <!DOCTYPE html><html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Tamer Mansour – Portfolio</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
+<head><meta charset="UTF-8"><title>Tamer Mansour – Portfolio</title>
+<link rel="stylesheet" href="css/style.css"></head>
 <body class="bg-white text-zinc-900">
-  <header class="p-6 flex justify-between items-center max-w-5xl mx-auto">
-    <h1 class="text-xl font-bold text-[var(--olive)]">Tamer Mansour</h1>
-    <a href="./ar/" class="underline text-sm">عربي</a>
-  </header>
+<header class="max-w-6xl mx-auto flex justify-between items-center p-6">
+  <h1 class="text-xl font-bold text-[var(--olive)]">Tamer Mansour</h1>
+  <nav>
+    <a href="#about">About</a><a href="#projects">Projects</a><a href="#media">Media</a><a href="#blog">Blog</a><a href="#contact">Contact</a>
+  </nav>
+  <button onclick="switchLang('ar')" class="underline text-sm">عربي</button>
+</header>
 
-  <section class="text-center py-20">
-    <!-- user will add real image later -->
-    <div class="w-40 h-40 rounded-full mx-auto shadow mb-6 bg-zinc-200 flex items-center justify-center text-sm text-zinc-500">profile.jpg</div>
-    <h2 class="text-4xl font-bold mb-4">Walk My AI Path — Unlock Your Future.</h2>
-    <p class="max-w-xl mx-auto mb-8">Blending AI mastery, creative vision, and a Palestinian spirit to inspire the next wave of innovators.</p>
-    <a href="#follow" class="px-6 py-3 rounded-full bg-[var(--olive)] text-white hover:shadow-lg">Follow My Work</a>
-  </section>
+<!-- Hero -->
+<section id="hero" class="text-center">
+  <img src="assets/profile.jpg" alt="profile" class="w-40 h-40 rounded-full mx-auto shadow mb-6" />
+  <h2 class="text-4xl font-bold mb-4">Walk My AI Path — Unlock Your Future.</h2>
+  <p class="max-w-xl mx-auto mb-8">Blending AI mastery, creative vision, and a Palestinian spirit to inspire the next wave of innovators.</p>
+  <a href="#follow" class="hero-btn">Follow My Work</a>
+</section>
 
-  <footer class="text-center py-6 text-sm bg-zinc-100">
-    © <span id="y"></span> Tamer Mansour — <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">Email me</a>
-  </footer>
-  <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
+<!-- About -->
+<section id="about" class="max-w-4xl mx-auto">
+  <h3 class="text-2xl font-bold mb-4">About Me</h3>
+  <p>I’m Tamer, a Palestinian AI consultant, filmmaker, and creator. I fuse technology and art to craft impactful experiences and help others prosper through AI‑powered creativity.</p>
+</section>
+
+<!-- Featured Projects -->
+<section id="projects" class="bg-zinc-100">
+  <h3 class="text-2xl font-bold text-center mb-6">Featured Projects</h3>
+  <div class="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto">
+    <!-- Card 1 -->
+    <article class="border rounded p-4">
+      <h4 class="font-semibold mb-2">Atyaf Al Ard</h4>
+      <p class="text-sm mb-2">AI‑generated documentary exploring Palestinian heritage.</p>
+      <a href="projects/atyaf.html" class="underline text-sm">Learn more</a>
+    </article>
+    <!-- TODO: more cards -->
+  </div>
+  <p class="text-center mt-6"><a href="projects/" class="underline">View all projects →</a></p>
+</section>
+
+<!-- AI Media Gallery -->
+<section id="media" class="max-w-6xl mx-auto">
+  <h3 class="text-2xl font-bold mb-6 text-center">AI Media Showcase</h3>
+  <p class="text-center text-sm mb-4">Images · Videos · Music (filter coming soon)</p>
+  <div class="grid md:grid-cols-4 gap-4">
+    <div class="aspect-square bg-zinc-200 flex items-center justify-center text-xs">placeholder</div>
+    <!-- Repeat placeholders -->
+  </div>
+</section>
+
+<!-- Blog / Insights teaser -->
+<section id="blog" class="bg-zinc-100">
+  <h3 class="text-2xl font-bold text-center mb-6">Latest Insights</h3>
+  <p class="text-center text-sm mb-4">Coming soon – deep dives & tutorials.</p>
+</section>
+
+<!-- Services placeholder -->
+<section id="services" class="max-w-4xl mx-auto">
+  <h3 class="text-2xl font-bold mb-4">Services (Coming Soon)</h3>
+  <ul class="list-disc pl-6"><li>AI Consulting</li><li>Workshops & Training</li><li>Creative Direction</li></ul>
+</section>
+
+<!-- Contact -->
+<section id="contact" class="text-center pt-12">
+  <h3 class="text-2xl font-bold mb-4">Get in Touch</h3>
+  <p>Email: <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">ai.visionary.pioneer@gmail.com</a></p>
+  <p>WhatsApp: +970 XXXX XXX</p>
+  <p class="mt-4 text-sm">© <span id="y"></span> Tamer Mansour</p>
+</section>
+
+<script src="js/main.js"></script>
+<script>document.getElementById('y').textContent=new Date().getFullYear();</script>
 </body></html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,5 @@
+/** simple lang toggle keeps current section */
+function switchLang(to){
+  const p=window.location.pathname;
+  window.location.href=to==='ar'?'/Tamer-Portfolio/ar/': '/Tamer-Portfolio/';
+}

--- a/docs/projects/ar/index.html
+++ b/docs/projects/ar/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html lang="ar" dir="rtl">
+<head><meta charset="UTF-8"><title>المشاريع – تامر منصور</title>
+<link rel="stylesheet" href="../../css/style.css"></head>
+<body class="bg-white text-zinc-900">
+<header class="max-w-6xl mx-auto flex justify-between items-center p-6">
+  <h1 class="text-xl font-bold text-[var(--olive)]">المشاريع</h1>
+  <a href="../" class="underline text-sm">EN</a>
+</header>
+<section class="max-w-4xl mx-auto text-center">
+  <h2 class="text-2xl font-bold mb-4">قائمة المشاريع قريباً</h2>
+  <p class="mb-6">ستظهر هنا دراسات تفصيلية للمشاريع.</p>
+  <a href="../../ar/" class="underline">← العودة للرئيسية</a>
+</section>
+<script src="../../js/main.js"></script>
+</body></html>

--- a/docs/projects/atyaf.html
+++ b/docs/projects/atyaf.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><html lang="en">
+<head><meta charset="UTF-8"><title>Atyaf Al Ard – Project</title>
+<link rel="stylesheet" href="../css/style.css"></head>
+<body class="bg-white text-zinc-900">
+<header class="max-w-6xl mx-auto flex justify-between items-center p-6">
+  <h1 class="text-xl font-bold text-[var(--olive)]">Atyaf Al Ard</h1>
+  <a href="../" class="underline text-sm">Home</a>
+</header>
+<section class="max-w-4xl mx-auto">
+  <p class="mb-4">Detailed description coming soon.</p>
+</section>
+<script src="../js/main.js"></script>
+</body></html>

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html lang="en">
+<head><meta charset="UTF-8"><title>Projects – Tamer Mansour</title>
+<link rel="stylesheet" href="../css/style.css"></head>
+<body class="bg-white text-zinc-900">
+<header class="max-w-6xl mx-auto flex justify-between items-center p-6">
+  <h1 class="text-xl font-bold text-[var(--olive)]">Projects</h1>
+  <a href="ar/" class="underline text-sm">عربي</a>
+</header>
+<section class="max-w-4xl mx-auto text-center">
+  <h2 class="text-2xl font-bold mb-4">Project List Coming Soon</h2>
+  <p class="mb-6">Detailed case studies will appear here.</p>
+  <a href="../" class="underline">← Back to home</a>
+</section>
+<script src="../js/main.js"></script>
+</body></html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,0 @@
-@import url("https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/dist/tailwind.min.css");
-:root{--olive:#556b2f;--gold:#cfaf3c;}
-body{font-family:"Inter",sans-serif;scroll-behavior:smooth;}


### PR DESCRIPTION
## Summary
- restructure `docs/` with css, js, projects and blog folders
- implement language switcher in `main.js`
- add full homepage sections (Hero, About, Projects, Media, Blog, Services, Contact) for English and Arabic
- add placeholder project and blog pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874018780c8832298090a8858496a70