### PR TITLE
Enable Media passthrough and update gallery images

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,6 +38,8 @@ module.exports = function (eleventyConfig) {
     return images.map((file) => ({ file }));
   });
 
+  eleventyConfig.addPassthroughCopy({ 'src/content/Media': 'Media' });
+
   return {
     // When hosted on GitHub Pages the site lives under the repository name,
     // so all links need this prefix. Keep it in sync with the repo name.

--- a/src/gallery.njk
+++ b/src/gallery.njk
@@ -5,6 +5,6 @@ title: Gallery
 
 <div class="gallery-grid">
   {% for img in collections.gallery %}
-    <img src="/Tamer-Portfolio/Media/{{ img.file }}" alt="{{ img.file }}">
+    <img src="{{ ('/Media/' + img.file) | url }}" alt="{{ img.file }}">
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- Add passthrough copy config for `src/content/Media` before Eleventy return
- Use Eleventy `url` filter for gallery image paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890acb2238883228ae4697a4b56d3e1