### PR TITLE
Finalize gallery support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 const path = require('path');
+const glob = require('glob');
 
 /**
  * Eleventy configuration for the Tamer Portfolio site.
@@ -28,14 +28,12 @@ module.exports = function (eleventyConfig) {
   // automatically in the gallery page. Only common image formats are
   // considered here; videos and other files will be ignored.
   eleventyConfig.addCollection('gallery', () => {
-    const mediaDir = path.join(__dirname, 'src', 'content', 'Media');
-    let images = [];
-    if (fs.existsSync(mediaDir)) {
-      images = fs
-        .readdirSync(mediaDir)
-        .filter((file) => /\.(png|jpe?g|gif|webp)$/i.test(file));
-    }
-    return images.map((file) => ({ file }));
+    return glob
+      .sync('src/content/Media/**/*.{png,jpg,jpeg,gif,webp}')
+      .map((filePath) => ({
+        fileName: path.basename(filePath),
+        url: filePath.replace('src/content', '')
+      }));
   });
 
   eleventyConfig.addPassthroughCopy({ 'src/content/Media': 'Media' });

--- a/src/gallery.njk
+++ b/src/gallery.njk
@@ -5,6 +5,6 @@ title: Gallery
 
 <div class="gallery-grid">
   {% for img in collections.gallery %}
-    <img src="{{ ('/Media/' + img.file) | url }}" alt="{{ img.file }}">
+    <img src="{{ img.url | url }}" alt="{{ img.fileName }}">
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- add glob-based `gallery` collection to expose image file names and urls
- update gallery template to use provided image metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b8a0385c8322b8ba2ad305edf727