### PR TITLE
Revamp home page with music showcase and new music page

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -2,27 +2,102 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Blog – Tamer Mansour</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/dist/tailwind.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Blog</title>
+  <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <div class="text-right p-4"><a href="../ar/blog/">عربي</a></div>
-  <main class="max-w-6xl mx-auto p-8">
-    <h1 class="text-2xl font-bold mb-4">Blog</h1>
-    <p>Articles will be posted here. <!-- TODO: list blog posts when available --></p>
-    <a href="../" class="underline block mt-6">← Home</a>
+  <header>
+    <nav>
+      <a href="/Tamer-Portfolio/">Home</a>
+      <a href="/Tamer-Portfolio/projects/">Projects</a>
+      <a href="/Tamer-Portfolio/media/">Media</a>
+      <a href="/Tamer-Portfolio/music/">Music</a>
+      <a href="/Tamer-Portfolio/gallery/">Gallery</a>
+      <a href="/Tamer-Portfolio/research/">Research</a>
+      <a href="/Tamer-Portfolio/training-consulting/">Training &amp; Consulting</a>
+      <a href="/Tamer-Portfolio/blog/">Blog</a>
+      <a href="/Tamer-Portfolio/about/">About</a>
+      <a href="/Tamer-Portfolio/contact/">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    
+<h1>Blog</h1>
+
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <article class="media-card">
+      <h2><a href="/content/blog/behind-the-ai-lens/">Behind the AI Lens</a></h2>
+      <p>Exploring how MidJourney and CapCut can be combined to craft cinematic narratives.
+</p>
+    </article>
+  
+
+  
+    <article class="media-card">
+      <h2><a href="/content/blog/creating-echoes-of-the-land/">Creating &#39;Echoes of the Land&#39;</a></h2>
+      <p>A behind‑the‑scenes look at the process behind the AI‑generated song &#39;Echoes of the Land&#39;.
+</p>
+    </article>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+
+<p>More articles coming soon.</p>
   </main>
-  <footer class="text-center py-6 text-sm">
-    © <span id="y"></span> Tamer Mansour ·
-    <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">Email</a> ·
-    <a href="https://www.facebook.com/teamo1985">FB</a> ·
-    <a href="https://www.instagram.com/tamerpalestine/">IG</a> ·
-    <a href="https://www.youtube.com/@TamerAI-e5i">YT</a> ·
-    <a href="https://www.tiktok.com/@ai_visionary_tm">TT</a> ·
-    <a href="https://www.pinterest.com/TamerCreates/">PT</a>
+
+  <footer>
+    <p>&copy; 2025 Tamer Mansour</p>
+    <div class="social-icons">
+      <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
+      </a>
+      <a href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" aria-label="TikTok">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/tiktok.svg" alt="TikTok icon">
+      </a>
+      <a href="https://www.youtube.com/@TamerAI-e5i" target="_blank" aria-label="YouTube">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/youtube.svg" alt="YouTube icon">
+      </a>
+    </div>
   </footer>
-  <script src="../js/theme.js"></script>
 </body>
 </html>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -2,30 +2,54 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Contact – Tamer Mansour</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/dist/tailwind.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact</title>
+  <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <div class="text-right p-4"><a href="../ar/contact/">عربي</a></div>
-  <main class="max-w-6xl mx-auto p-8 text-center">
-    <h1 class="text-2xl font-bold mb-4">Contact</h1>
-    <p class="mb-2">Email – <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">ai.visionary.pioneer@gmail.com</a></p>
-    <p class="mb-2">WhatsApp / Telegram – coming soon</p>
-    <p class="mb-2">LinkedIn – <!-- TODO: add LinkedIn profile link -->coming soon</p>
-    <!-- TODO: add other social links if needed -->
-    <a href="../" class="underline block mt-6">← Home</a>
+  <header>
+    <nav>
+      <a href="/Tamer-Portfolio/">Home</a>
+      <a href="/Tamer-Portfolio/projects/">Projects</a>
+      <a href="/Tamer-Portfolio/media/">Media</a>
+      <a href="/Tamer-Portfolio/music/">Music</a>
+      <a href="/Tamer-Portfolio/gallery/">Gallery</a>
+      <a href="/Tamer-Portfolio/research/">Research</a>
+      <a href="/Tamer-Portfolio/training-consulting/">Training &amp; Consulting</a>
+      <a href="/Tamer-Portfolio/blog/">Blog</a>
+      <a href="/Tamer-Portfolio/about/">About</a>
+      <a href="/Tamer-Portfolio/contact/">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    
+<h1>Contact</h1>
+
+<p>You can reach me via email at <a href="mailto:ai.visionary.pioneer@gmail.com">ai.visionary.pioneer@gmail.com</a>.</p>
+<p>WhatsApp: <a href="https://wa.me/970599797245">+970 599 797 245</a> | <a href="https://wa.me/970592037973">+970 592 037 973</a></p>
+
+<p>Follow or message me on my social channels:</p>
+<ul>
+  <li><a href="https://www.pinterest.com/TamerCreates/" target="_blank">Pinterest</a></li>
+  <li><a href="https://www.tiktok.com/@ai_visionary_tm" target="_blank">TikTok</a></li>
+  <li><a href="https://www.youtube.com/@TamerAI-e5i" target="_blank">YouTube</a></li>
+</ul>
   </main>
-  <footer class="text-center py-6 text-sm">
-    © <span id="y"></span> Tamer Mansour ·
-    <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">Email</a> ·
-    <a href="https://www.facebook.com/teamo1985">FB</a> ·
-    <a href="https://www.instagram.com/tamerpalestine/">IG</a> ·
-    <a href="https://www.youtube.com/@TamerAI-e5i">YT</a> ·
-    <a href="https://www.tiktok.com/@ai_visionary_tm">TT</a> ·
-    <a href="https://www.pinterest.com/TamerCreates/">PT</a>
+
+  <footer>
+    <p>&copy; 2025 Tamer Mansour</p>
+    <div class="social-icons">
+      <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
+      </a>
+      <a href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" aria-label="TikTok">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/tiktok.svg" alt="TikTok icon">
+      </a>
+      <a href="https://www.youtube.com/@TamerAI-e5i" target="_blank" aria-label="YouTube">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/youtube.svg" alt="YouTube icon">
+      </a>
+    </div>
   </footer>
-  <script src="../js/theme.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,105 +2,112 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Tamer Mansour — Portfolio</title>
-
-  <!-- Tailwind CDN -->
-  <script src="https://cdn.tailwindcss.com"></script>
-
-  <!-- Font Awesome icons -->
-  <script src="https://kit.fontawesome.com/93b517e3ae.js" crossorigin="anonymous"></script>
-
-  <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
-
-  <!-- Custom CSS -->
-  <link rel="stylesheet" href="style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Home</title>
+  <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-<header id="nav" class="nav-shadow fixed inset-x-0 bg-[rgba(247,247,245,0.8)] backdrop-blur-md z-50">
-  <div class="max-w-6xl mx-auto flex justify-between items-center px-4 py-3">
-    <a href="/Tamer-Portfolio/" class="font-bold text-lg text-[var(--olive)]">Tamer&nbsp;Mansour</a>
-
-    <!-- NAVBAR LINKS -->
-    <nav class="flex items-center gap-5 text-sm">
-      <a href="#about">About</a>
-      <a href="#projects">Projects</a>
-      <a href="#media">Media</a>
-      <a href="#contact">Contact</a>
-      <a href="ar/" class="underline">عربي</a>
-
-      <!-- SOCIAL ICONS -->
-      <div class="social flex gap-2">
-        <a href="https://www.facebook.com/teamo1985" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
-        <a href="https://www.instagram.com/tamerpalestine/" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
-        <a href="https://www.youtube.com/@TamerAI-e5i" aria-label="YouTube"><i class="fab fa-youtube"></i></a>
-        <a href="https://www.tiktok.com/@ai_visionary_tm" aria-label="TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.pinterest.com/TamerCreates/" aria-label="Pinterest"><i class="fab fa-pinterest-p"></i></a>
-      </div>
-
-      <!-- THEME TOGGLE -->
-      <button id="theme" class="border rounded px-2 ml-2">🌓</button>
+  <header>
+    <nav>
+      <a href="/Tamer-Portfolio/">Home</a>
+      <a href="/Tamer-Portfolio/projects/">Projects</a>
+      <a href="/Tamer-Portfolio/media/">Media</a>
+      <a href="/Tamer-Portfolio/music/">Music</a>
+      <a href="/Tamer-Portfolio/gallery/">Gallery</a>
+      <a href="/Tamer-Portfolio/research/">Research</a>
+      <a href="/Tamer-Portfolio/training-consulting/">Training &amp; Consulting</a>
+      <a href="/Tamer-Portfolio/blog/">Blog</a>
+      <a href="/Tamer-Portfolio/about/">About</a>
+      <a href="/Tamer-Portfolio/contact/">Contact</a>
     </nav>
-  </div>
-</header>
+  </header>
 
-<main class="pt-24">
-  <!-- Hero -->
-  <section id="hero" class="text-center py-24">
-    <img src="assets/profile.png" class="w-40 h-40 rounded-full mx-auto shadow mb-6" alt="profile">
-    <h1 class="text-4xl font-bold mb-4">Walk My AI Path — Unlock Your Future.</h1>
-    <p class="max-w-xl mx-auto mb-8">Blending AI mastery, creative vision, and a Palestinian spirit to inspire the next wave of innovators.</p>
-    <a href="#contact" class="btn-glow">Follow My Work</a>
-  </section>
+  <main>
+    
+<section class="hero block">
+  <h1>AI, Identity &amp; Imagination Intertwined</h1>
+  <p>Crafting futures with technology, grounded in history</p>
+  <a href="/Tamer-Portfolio/projects/" class="btn">Explore the Work</a>
+</section>
 
-  <!-- About -->
-  <section id="about" class="max-w-5xl mx-auto py-16 px-4">
-    <h2 class="text-2xl font-bold mb-4">About&nbsp;Me</h2>
-    <p>I’m Tamer, a Palestinian AI consultant &amp; creative with a mindset that bends rules. I merge technology, art, and cultural identity to craft future-proof experiences.</p>
-  </section>
-
-  <!-- Projects teaser -->
-  <section id="projects" class="bg-zinc-50 py-16 px-4">
-    <div class="max-w-6xl mx-auto">
-      <h2 class="text-2xl font-bold mb-8">Featured Projects</h2>
-      <p class="mb-4">Coming soon: Atyaf&nbsp;Al&nbsp;Ard, generative music tools, AI film pipelines…</p>
-      <a href="projects/" class="btn-glow">View All Projects</a>
+<section id="featured-videos" class="block">
+  <h2>Featured Videos</h2>
+  <article class="media-card">
+    <h3>أنا الأرض: قصيدة مصوّرة على لسان فلسطين</h3>
+    <div class="video-wrapper">
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/dqGQJQ1jvHg"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
     </div>
-  </section>
-
-  <!-- Media teaser -->
-  <section id="media" class="py-16 px-4">
-    <div class="max-w-6xl mx-auto text-center">
-      <h2 class="text-2xl font-bold mb-8">AI Media Gallery</h2>
-      <p class="mb-4">Images • Videos • Music – filterable showcase coming soon.</p>
-      <a href="media/" class="btn-glow">Enter Gallery</a>
+  </article>
+  <article class="media-card">
+    <h3>Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos</h3>
+    <div class="video-wrapper">
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/TcxHhyMLvfo"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
     </div>
-  </section>
+  </article>
+</section>
 
-  <!-- Blog teaser -->
-  <section class="bg-zinc-50 py-16 px-4">
-    <div class="max-w-6xl mx-auto text-center">
-      <h2 class="text-2xl font-bold mb-8">Latest Articles</h2>
-      <p class="mb-4">Thoughts on AI ethics, creative workflows, and Palestinian tech scenes.</p>
-      <a href="blog/" class="btn-glow">Read the Blog</a>
+<section id="music-preview" class="block">
+  <h2>Sound Experiments</h2>
+  <article class="music-card">
+    <h3>Forgotten Sparks</h3>
+    <p>marimba pulses, evolving pads, faint AM-radio texture</p>
+    <p><a href="https://suno.com/s/JUT6IYjmiTbpyjiu" target="_blank">Listen on Suno</a></p>
+  </article>
+  <article class="music-card">
+    <h3>Dreamcatcher Glow</h3>
+    <p>warm tape saturation, lo-fi lullaby, nostalgic vinyl crackle</p>
+    <p><a href="https://suno.com/s/0EFHyII8YjDHrPdg" target="_blank">Listen on Suno</a></p>
+  </article>
+</section>
+
+<section id="training" class="block">
+  <h2>AI Training &amp; Workshops</h2>
+  <p>Over the past year I’ve mentored professionals, kids, and elders on how to customise generative-AI tools. My approach? Build a flexible mindset that’s future-ready, not trapped in yesterday’s paradigms.</p>
+</section>
+
+<section id="inspiration" class="block">
+  <h2>Inspiration Boards</h2>
+  <ul>
+    <li>
+      <strong>Brides of Civilizations: A Global Couture Wedding</strong><br>
+      20 AI-imagined bridal looks across ten ancient cultures.<br>
+      <a href="https://www.pinterest.com/TamerCreates/brides-of-civilizations/" target="_blank">Explore on Pinterest</a>
+    </li>
+    <li>
+      <strong>Mythic Butterfly Visions</strong><br>
+      Metallic butterflies &amp; botanical masks fuse into high-fashion portraits.<br>
+      <a href="https://www.pinterest.com/TamerCreates/mythic-butterfly-visions/" target="_blank">Explore on Pinterest</a>
+    </li>
+  </ul>
+</section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Tamer Mansour</p>
+    <div class="social-icons">
+      <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
+      </a>
+      <a href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" aria-label="TikTok">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/tiktok.svg" alt="TikTok icon">
+      </a>
+      <a href="https://www.youtube.com/@TamerAI-e5i" target="_blank" aria-label="YouTube">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/youtube.svg" alt="YouTube icon">
+      </a>
     </div>
-  </section>
-
-  <!-- Contact -->
-  <section id="contact" class="max-w-5xl mx-auto py-16 px-4 text-center">
-    <h2 class="text-2xl font-bold mb-4">Get&nbsp;in Touch</h2>
-    <p class="mb-4">
-      Email – <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">ai.visionary.pioneer@gmail.com</a><br>
-      WhatsApp / Telegram – coming soon
-    </p>
-  </section>
-</main>
-
-<footer class="text-center py-6 text-xs">
-  © <span id="y"></span> Tamer Mansour · 
-  <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">Email</a>
-</footer>
-
-<script src="js/theme.js"></script>
+  </footer>
 </body>
 </html>

--- a/docs/media/index.html
+++ b/docs/media/index.html
@@ -2,47 +2,116 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Media – Tamer Mansour</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.0/dist/tailwind.min.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Media</title>
+  <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <div class="text-right p-4"><a href="../ar/media/">عربي</a></div>
-  <main class="max-w-6xl mx-auto p-8">
-    <h1 class="text-2xl font-bold mb-6">Media Gallery</h1>
-    <h2 class="text-xl font-bold mt-8 mb-4">Images</h2>
-    <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-      <img src="../assets/image1.jpg" alt="Media image 1" class="w-full">
-      <!-- TODO: other images -->
-    </div>
-    <h2 class="text-xl font-bold mt-12 mb-4">Videos</h2>
-    <div class="space-y-4">
-      <video controls class="w-full">
-        <source src="../assets/video1.mp4" type="video/mp4">
-        Your browser does not support the video tag.
-      </video>
-      <!-- TODO: other videos -->
-    </div>
-    <h2 class="text-xl font-bold mt-12 mb-4">Audio</h2>
-    <div class="space-y-2">
-      <audio controls>
-        <source src="../assets/audio1.mp3" type="audio/mpeg">
-        Your browser does not support the audio element.
-      </audio>
-      <!-- TODO: other audio files -->
-    </div>
-    <a href="../" class="underline block mt-8">← Home</a>
+  <header>
+    <nav>
+      <a href="/Tamer-Portfolio/">Home</a>
+      <a href="/Tamer-Portfolio/projects/">Projects</a>
+      <a href="/Tamer-Portfolio/media/">Media</a>
+      <a href="/Tamer-Portfolio/music/">Music</a>
+      <a href="/Tamer-Portfolio/gallery/">Gallery</a>
+      <a href="/Tamer-Portfolio/research/">Research</a>
+      <a href="/Tamer-Portfolio/training-consulting/">Training &amp; Consulting</a>
+      <a href="/Tamer-Portfolio/blog/">Blog</a>
+      <a href="/Tamer-Portfolio/about/">About</a>
+      <a href="/Tamer-Portfolio/contact/">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    
+<h1>Media</h1>
+
+
+  <article class="media-card">
+    <h2><a href="/content/Media/ai-youth-session/">AI Youth Session Video</a></h2>
+    <p>Recording of a youth AI workshop session, discussing the future of AI and its impact on society.
+</p>
+    
+      <div class="video-wrapper">
+        <iframe
+          width="560"
+          height="315"
+          src="https://drive.google.com/file/d/1jGR-P_EeVjXBMkVphaERreJLbpORcQu0/preview"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+      </div>
+    
+  </article>
+
+  <article class="media-card">
+    <h2><a href="/content/media/echoes-of-the-land/">Echoes of the Land – A Song from the Heart of Palestine</a></h2>
+    <p>A song from the heart of Palestine, blending traditional melodies with AI‑generated arrangements.
+</p>
+    
+      <div class="video-wrapper">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/o5f5cjZw_j8"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+      </div>
+    
+  </article>
+
+  <article class="media-card">
+    <h2><a href="/content/media/mona-lisa-glitch-mode/">Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos</a></h2>
+    <p>An experimental short film exploring the chaos of AI glitch aesthetics using the Mona Lisa as a muse.
+</p>
+    
+      <div class="video-wrapper">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/TcxHhyMLvfo"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+      </div>
+    
+  </article>
+
+  <article class="media-card">
+    <h2><a href="/content/media/ana-al-ard/">أنا الأرض: قصيدة مصوّرة على لسان فلسطين</a></h2>
+    <p>قصيدة مصوّرة تحيي قصيدة محمود درويش &quot;أنا الأرض&quot;، مستخدمة الذكاء الاصطناعي لنسج صورة وصوت يحاكيان روح فلسطين.
+</p>
+    
+      <div class="video-wrapper">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/dqGQJQ1jvHg"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+      </div>
+    
+  </article>
+
+
+
   </main>
-  <footer class="text-center py-6 text-sm">
-    © <span id="y"></span> Tamer Mansour ·
-    <a href="mailto:ai.visionary.pioneer@gmail.com" class="underline">Email</a> ·
-    <a href="https://www.facebook.com/teamo1985">FB</a> ·
-    <a href="https://www.instagram.com/tamerpalestine/">IG</a> ·
-    <a href="https://www.youtube.com/@TamerAI-e5i">YT</a> ·
-    <a href="https://www.tiktok.com/@ai_visionary_tm">TT</a> ·
-    <a href="https://www.pinterest.com/TamerCreates/">PT</a>
+
+  <footer>
+    <p>&copy; 2025 Tamer Mansour</p>
+    <div class="social-icons">
+      <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
+      </a>
+      <a href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" aria-label="TikTok">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/tiktok.svg" alt="TikTok icon">
+      </a>
+      <a href="https://www.youtube.com/@TamerAI-e5i" target="_blank" aria-label="YouTube">
+        <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/youtube.svg" alt="YouTube icon">
+      </a>
+    </div>
   </footer>
-  <script src="../js/theme.js"></script>
 </body>
 </html>

--- a/docs/music/index.html
+++ b/docs/music/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Projects</title>
+  <title>Music</title>
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
@@ -24,22 +24,21 @@
 
   <main>
     
-<h1>Projects</h1>
+<h1>Music</h1>
 
-<h2>AI Projects</h2>
-<ul>
-  <li><strong>Khaial</strong> – A generative AI exploration mixing Arabic calligraphy and data to reimagine cultural motifs.</li>
-</ul>
+<section class="block">
+  <article class="music-card">
+    <h2>Forgotten Sparks</h2>
+    <p>marimba pulses, evolving pads, faint AM-radio texture</p>
+    <p><a href="https://suno.com/s/JUT6IYjmiTbpyjiu" target="_blank">Listen on Suno</a></p>
+  </article>
+  <article class="music-card">
+    <h2>Dreamcatcher Glow</h2>
+    <p>warm tape saturation, lo-fi lullaby, nostalgic vinyl crackle</p>
+    <p><a href="https://suno.com/s/0EFHyII8YjDHrPdg" target="_blank">Listen on Suno</a></p>
+  </article>
+</section>
 
-<h2>Film Projects</h2>
-<ul>
-  <li><strong>Echoes of the Land</strong> – A song from the heart of Palestine.</li>
-  <li><strong>أنا الأرض</strong> – قصيدة مصوّرة على لسان فلسطين.</li>
-  <li><strong>Mona&nbsp;Lisa in Glitch Mode</strong> – 3 min 30 s of AI chaos.</li>
-  <li><strong>Mandela's Dawn</strong> – The road to freedom.</li>
-</ul>
-
-<p>For a full list of work, browse the media and gallery sections.</p>
   </main>
 
   <footer>

--- a/src/index.njk
+++ b/src/index.njk
@@ -3,29 +3,71 @@ layout: base.njk
 title: Home
 ---
 
-<section class="hero">
+<section class="hero block">
   <h1>AI, Identity &amp; Imagination Intertwined</h1>
   <p>Crafting futures with technology, grounded in history</p>
   <a href="/Tamer-Portfolio/projects/" class="btn">Explore the Work</a>
 </section>
 
-<section>
+<section id="featured-videos" class="block">
   <h2>Featured Videos</h2>
-  {% for item in collections.media %}
-    <article class="media-card">
-      <h3><a href="{{ item.url }}">{{ item.data.title }}</a></h3>
-      <p>{{ item.data.excerpt }}</p>
-      {% if item.data.embed_url %}
-        <div class="video-wrapper">
-          <iframe
-            width="560"
-            height="315"
-            src="{{ item.data.embed_url | youtubeEmbed }}"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen></iframe>
-        </div>
-      {% endif %}
-    </article>
-  {% endfor %}
+  <article class="media-card">
+    <h3>أنا الأرض: قصيدة مصوّرة على لسان فلسطين</h3>
+    <div class="video-wrapper">
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/dqGQJQ1jvHg"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
+    </div>
+  </article>
+  <article class="media-card">
+    <h3>Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos</h3>
+    <div class="video-wrapper">
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/TcxHhyMLvfo"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
+    </div>
+  </article>
+</section>
+
+<section id="music-preview" class="block">
+  <h2>Sound Experiments</h2>
+  <article class="music-card">
+    <h3>Forgotten Sparks</h3>
+    <p>marimba pulses, evolving pads, faint AM-radio texture</p>
+    <p><a href="https://suno.com/s/JUT6IYjmiTbpyjiu" target="_blank">Listen on Suno</a></p>
+  </article>
+  <article class="music-card">
+    <h3>Dreamcatcher Glow</h3>
+    <p>warm tape saturation, lo-fi lullaby, nostalgic vinyl crackle</p>
+    <p><a href="https://suno.com/s/0EFHyII8YjDHrPdg" target="_blank">Listen on Suno</a></p>
+  </article>
+</section>
+
+<section id="training" class="block">
+  <h2>AI Training &amp; Workshops</h2>
+  <p>Over the past year I’ve mentored professionals, kids, and elders on how to customise generative-AI tools. My approach? Build a flexible mindset that’s future-ready, not trapped in yesterday’s paradigms.</p>
+</section>
+
+<section id="inspiration" class="block">
+  <h2>Inspiration Boards</h2>
+  <ul>
+    <li>
+      <strong>Brides of Civilizations: A Global Couture Wedding</strong><br>
+      20 AI-imagined bridal looks across ten ancient cultures.<br>
+      <a href="https://www.pinterest.com/TamerCreates/brides-of-civilizations/" target="_blank">Explore on Pinterest</a>
+    </li>
+    <li>
+      <strong>Mythic Butterfly Visions</strong><br>
+      Metallic butterflies &amp; botanical masks fuse into high-fashion portraits.<br>
+      <a href="https://www.pinterest.com/TamerCreates/mythic-butterfly-visions/" target="_blank">Explore on Pinterest</a>
+    </li>
+  </ul>
 </section>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -12,6 +12,7 @@
       <a href="/Tamer-Portfolio/">Home</a>
       <a href="/Tamer-Portfolio/projects/">Projects</a>
       <a href="/Tamer-Portfolio/media/">Media</a>
+      <a href="/Tamer-Portfolio/music/">Music</a>
       <a href="/Tamer-Portfolio/gallery/">Gallery</a>
       <a href="/Tamer-Portfolio/research/">Research</a>
       <a href="/Tamer-Portfolio/training-consulting/">Training &amp; Consulting</a>

--- a/src/music.njk
+++ b/src/music.njk
@@ -1,0 +1,17 @@
+---
+layout: page.njk
+title: Music
+---
+
+<section class="block">
+  <article class="music-card">
+    <h2>Forgotten Sparks</h2>
+    <p>marimba pulses, evolving pads, faint AM-radio texture</p>
+    <p><a href="https://suno.com/s/JUT6IYjmiTbpyjiu" target="_blank">Listen on Suno</a></p>
+  </article>
+  <article class="music-card">
+    <h2>Dreamcatcher Glow</h2>
+    <p>warm tape saturation, lo-fi lullaby, nostalgic vinyl crackle</p>
+    <p><a href="https://suno.com/s/0EFHyII8YjDHrPdg" target="_blank">Listen on Suno</a></p>
+  </article>
+</section>


### PR DESCRIPTION
## Summary
- Replace dynamic video loop on the home page with two fixed featured videos and add new Sound Experiments, Training, and Pinterest sections.
- Introduce a dedicated Music page and link it in the site navigation.

## Testing
- `npx eleventy --output=docs`

------
https://chatgpt.com/codex/tasks/task_e_6891022f39ac83228a6122e0357a63a0