### PR TITLE
feat(home): add portfolio hero image and Pinterest embeds

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -9,6 +9,18 @@ title: Home
   <a href="/Tamer-Portfolio/projects/" class="btn">Explore the Work</a>
 </section>
 
+<!-- BEGIN: Portfolio Hero Figure -->
+<section id="portfolio-hero" class="container">
+  <figure class="portfolio-figure">
+    <img
+      src="https://cdn.midjourney.com/b37b2670-89dd-43d3-82f4-803445498bae/0_3.png"
+      alt="Tamer Mansour — featured AI visual exploring identity, memory, and imagination"
+      loading="lazy" />
+    <figcaption>AI-driven visual — identity, memory, imagination. © Tamer Mansour</figcaption>
+  </figure>
+</section>
+<!-- END: Portfolio Hero Figure -->
+
 <section id="about" class="block">
   <h2>About Me</h2>
   <p>Hi, I’m <strong>Tamer Mansour</strong> — a Palestinian AI consultant
@@ -68,17 +80,24 @@ title: Home
   </ul>
 </section>
 
-<section id="art-preview" class="block">
+
+<!-- BEGIN: Artistic Snapshots (updated) -->
+<section id="artistic-snapshots" class="container section-pad">
   <h2>Artistic Snapshots</h2>
-  <div class="gallery-mini">
-    {% for img in collections.gallery | slice(0,3) %}
-      <a href="/Tamer-Portfolio/gallery/">
-        <img src="{{ img.url | url }}" alt="{{ img.fileName }}">
-      </a>
-    {% endfor %}
+  <div class="art-grid">
+    <a class="art-card" href="https://cdn.midjourney.com/d945cbb5-5395-4dbd-bdee-88c574e1968e/0_1.png" target="_blank" rel="noopener">
+      <img src="https://cdn.midjourney.com/d945cbb5-5395-4dbd-bdee-88c574e1968e/0_1.png" alt="Editorial portrait — metallic motifs and soft chiaroscuro" loading="lazy">
+    </a>
+    <a class="art-card" href="https://cdn.midjourney.com/9c939e43-8b62-49d4-ae44-990575f1291d/0_2.png" target="_blank" rel="noopener">
+      <img src="https://cdn.midjourney.com/9c939e43-8b62-49d4-ae44-990575f1291d/0_2.png" alt="Fashion-inspired cinematic frame with layered textures" loading="lazy">
+    </a>
+    <a class="art-card" href="https://cdn.midjourney.com/6e63233f-c9f6-40da-8c5e-385f310ac779/0_2.png" target="_blank" rel="noopener">
+      <img src="https://cdn.midjourney.com/6e63233f-c9f6-40da-8c5e-385f310ac779/0_2.png" alt="Surreal-minimal study — masks, lines, and quiet symmetry" loading="lazy">
+    </a>
   </div>
-  <p class="small">See more in the <a href="/Tamer-Portfolio/gallery/">full gallery</a>.</p>
+  <p class="more-link"><a href="/Tamer-Portfolio/media/">See more in the full gallery →</a></p>
 </section>
+<!-- END: Artistic Snapshots (updated) -->
 
 <section id="training" class="block">
   <h2>AI Training &amp; Workshops</h2>
@@ -91,18 +110,34 @@ title: Home
      — and take them further.</p>
 </section>
 
-<section id="inspiration" class="block">
+<!-- BEGIN: Inspiration Boards (embedded) -->
+<section id="inspiration" class="container section-pad">
   <h2>Inspiration Boards</h2>
-  <ul>
-    <li>
-        <strong>Brides of Civilizations: A Global Couture Wedding</strong><br>
-        20 AI-imagined bridal looks across ten ancient cultures.<br>
-        <a href="https://pin.it/5HP2SxlGQ" target="_blank">Explore on Pinterest</a>
-      </li>
-    <li>
-      <strong>Mythic Butterfly Visions</strong><br>
-      Metallic butterflies &amp; botanical masks fuse into high-fashion portraits.<br>
-      <a href="https://www.pinterest.com/TamerCreates/mythic-butterfly-visions/" target="_blank">Explore on Pinterest</a>
-    </li>
-  </ul>
+  <div class="pinterest-boards">
+    <div class="p-board">
+      <a
+        data-pin-do="embedBoard"
+        href="https://www.pinterest.com/TamerCreates/brides-of-civilizations-a-global-couture-wedding/"
+        data-pin-board-width="520"
+        data-pin-scale-height="360"
+        data-pin-scale-width="120">
+      </a>
+    </div>
+    <div class="p-board">
+      <a
+        data-pin-do="embedBoard"
+        href="https://www.pinterest.com/TamerCreates/mythic-butterfly-visions/"
+        data-pin-board-width="520"
+        data-pin-scale-height="360"
+        data-pin-scale-width="120">
+      </a>
+    </div>
+  </div>
+  <noscript>
+    <ul>
+      <li><a href="https://www.pinterest.com/TamerCreates/brides-of-civilizations-a-global-couture-wedding/">Brides of Civilizations on Pinterest</a></li>
+      <li><a href="https://www.pinterest.com/TamerCreates/mythic-butterfly-visions/">Mythic Butterfly Visions on Pinterest</a></li>
+    </ul>
+  </noscript>
 </section>
+<!-- END: Inspiration Boards (embedded) -->

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -40,5 +40,6 @@
       </a>
     </div>
   </footer>
+  <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
 </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,3 +145,34 @@ footer .social-icons a img {
   margin: 1rem 0 2rem;
 }
 .gallery-mini img { width: 100%; border-radius: 12px; }
+
+:root {
+  --olive: #6a7f4e;
+  --ink: #0e1116;
+  --stone: #f4f4f2;
+}
+.container { max-width: 1100px; margin: 0 auto; padding: 0 1rem; }
+.section-pad { padding: 3rem 0; }
+/* Portfolio hero figure */
+.portfolio-figure {
+  display: grid; gap: .75rem;
+  border: 1px solid var(--olive);
+  border-radius: 16px;
+  padding: .75rem;
+  background: linear-gradient(0deg, rgba(106,127,78,.06), rgba(106,127,78,.06)), var(--stone);
+  box-shadow: 0 8px 24px rgba(0,0,0,.08);
+}
+.portfolio-figure img { width: 100%; height: auto; display: block; border-radius: 12px; }
+.portfolio-figure figcaption { font-size: .9rem; color: #444; }
+/* Artistic Snapshots grid */
+.art-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+@media (max-width: 900px) { .art-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 600px) { .art-grid { grid-template-columns: 1fr; } }
+.art-card { display: block; overflow: hidden; border-radius: 14px; border: 1px solid rgba(0,0,0,.06); background: #fff; box-shadow: 0 4px 16px rgba(0,0,0,.06); }
+.art-card img { width: 100%; height: auto; display: block; transition: transform .5s ease; }
+.art-card:hover img { transform: scale(1.03); }
+.more-link { margin-top: 1rem; }
+/* Pinterest boards layout */
+.pinterest-boards { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
+@media (max-width: 900px) { .pinterest-boards { grid-template-columns: 1fr; } }
+.p-board { background: var(--stone); border-radius: 16px; padding: .5rem; border: 1px solid rgba(0,0,0,.06); }


### PR DESCRIPTION
## Summary
- showcase new MidJourney hero image and refresh artistic snapshots grid
- embed Pinterest inspiration boards and load widget globally
- append responsive layout styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68963a6803388322add1c275f6455d8e