### PR TITLE
feat(home): add section images and styling updates

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -13,9 +13,9 @@ title: Home
 <section id="portfolio-hero" class="container">
   <figure class="portfolio-figure">
     <img
-      src="https://cdn.midjourney.com/b37b2670-89dd-43d3-82f4-803445498bae/0_3.png"
-      alt="Tamer Mansour — featured AI visual exploring identity, memory, and imagination"
-      loading="lazy" />
+      src="https://cdn.midjourney.com/da24e68c-5f4b-4dad-9242-072ebe5edd68/0_2.png"
+      alt="Editorial portrait of Tamer Mansour — cinematic, olive/cream palette"
+      loading="lazy" decoding="async" fetchpriority="high" width="1600" height="900" />
     <figcaption>AI-driven visual — identity, memory, imagination. © Tamer Mansour</figcaption>
   </figure>
 </section>
@@ -23,6 +23,11 @@ title: Home
 
 <section id="about" class="block">
   <h2>About Me</h2>
+  <figure class="about-visual">
+    <img src="https://cdn.midjourney.com/5be07b3b-3f0e-495d-ac13-fc634ab86ddd/0_0.png"
+         alt="Minimal desk scene with olive branch and laptop — brand accent"
+         loading="lazy" decoding="async" width="1200" height="800" />
+  </figure>
   <p>Hi, I’m <strong>Tamer Mansour</strong> — a Palestinian AI consultant
      and creative explorer. I work solo as a freelancer, crafting ideas
      into reality using AI tools across sound, visuals, education, and
@@ -38,6 +43,11 @@ title: Home
 
 <section id="featured-videos" class="block">
   <h2>Featured Videos</h2>
+  <figure class="video-cover">
+    <img src="https://cdn.midjourney.com/1353bb66-9b1a-42cd-b67e-8b7c51381c18/0_2.png"
+         alt="Cinematic collage blending heritage and technology"
+         loading="lazy" decoding="async" width="1600" height="900" />
+  </figure>
   <article class="media-card">
     <h3>أنا الأرض: قصيدة مصوّرة على لسان فلسطين</h3>
     <div class="video-wrapper">
@@ -66,6 +76,11 @@ title: Home
 
 <section id="sound-experiments" class="block">
   <h2>Sound Experiments</h2>
+  <figure class="sound-thumb">
+    <img src="https://cdn.midjourney.com/86fd5d11-5a36-4b79-9ed2-a5a94fa81939/0_2.png"
+         alt="Vintage microphone with subtle Palestinian embroidery pattern"
+         loading="lazy" decoding="async" width="800" height="800" />
+  </figure>
   <ul class="music-list">
     <li>
       <strong>Forgotten Sparks</strong> — marimba pulses, evolving pads,
@@ -94,6 +109,11 @@ title: Home
     <a class="art-card" href="https://cdn.midjourney.com/6e63233f-c9f6-40da-8c5e-385f310ac779/0_2.png" target="_blank" rel="noopener">
       <img src="https://cdn.midjourney.com/6e63233f-c9f6-40da-8c5e-385f310ac779/0_2.png" alt="Surreal-minimal study — masks, lines, and quiet symmetry" loading="lazy">
     </a>
+    <a class="art-card" href="https://cdn.midjourney.com/3be26269-f52e-48b1-bc7c-8f6b0cc02382/0_1.png" target="_blank" rel="noopener">
+      <img src="https://cdn.midjourney.com/3be26269-f52e-48b1-bc7c-8f6b0cc02382/0_1.png"
+           alt="Avant‑garde fashion portrait with embroidery details"
+           loading="lazy" decoding="async" />
+    </a>
   </div>
   <p class="more-link"><a href="/Tamer-Portfolio/media/">See more in the full gallery →</a></p>
 </section>
@@ -101,6 +121,11 @@ title: Home
 
 <section id="training" class="block">
   <h2>AI Training &amp; Workshops</h2>
+  <figure class="workshops-visual">
+    <img src="https://cdn.midjourney.com/6ca23085-8292-44eb-a78e-1d99062abae7/0_3.png"
+         alt="Hands‑on AI workshop scene with participants and screen"
+         loading="lazy" decoding="async" width="1600" height="900" />
+  </figure>
   <p>Over the past year, I’ve mentored professionals, kids, and elders on how
      to customise generative-AI tools — not just to use them, but to think with
      them. My approach is personal: no cookie-cutter methods, just deep

--- a/src/styles.css
+++ b/src/styles.css
@@ -176,3 +176,27 @@ footer .social-icons a img {
 .pinterest-boards { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
 @media (max-width: 900px) { .pinterest-boards { grid-template-columns: 1fr; } }
 .p-board { background: var(--stone); border-radius: 16px; padding: .5rem; border: 1px solid rgba(0,0,0,.06); }
+
+/* kufiya accent behind hero image */
+.portfolio-figure{ position: relative; }
+.portfolio-figure::before{
+  content: ""; position: absolute; inset: 0; z-index: 0;
+  background-image: url('https://cdn.midjourney.com/b9358230-0e6d-4e21-ae02-a171d1b36766/0_1.png');
+  background-size: cover; background-position: center; background-repeat: no-repeat;
+  opacity: .06; filter: contrast(.9) saturate(.9);
+  border-radius: 12px; /* match inner radius */
+}
+.portfolio-figure > *{ position: relative; z-index: 1; }
+
+/* shared figure styles */
+.about-visual, .video-cover, .sound-thumb, .workshops-visual{
+  margin: 1rem 0 1.25rem; border: 1px solid rgba(0,0,0,.08); border-radius: 14px;
+  padding: .5rem; background: #fff; box-shadow: 0 6px 18px rgba(0,0,0,.07);
+}
+.about-visual img, .video-cover img, .sound-thumb img, .workshops-visual img{
+  display:block; width:100%; height:auto; border-radius: 10px;
+}
+/* make Sound Experiments thumbnail float on wide screens */
+@media (min-width: 900px){
+  .sound-thumb{ float:right; width: 34%; margin-left: 1rem; }
+}


### PR DESCRIPTION
## Summary
- replace hero figure and add decorative images to About, Videos, Sound, and Workshops
- expand Artistic Snapshots to four items
- add kufiya accent and shared figure styles

## Testing
- `npm test` *(missing script: test)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689647a90a1c8322b256ba488c82660c