### PR TITLE
fix(home): convert Suno links into cards, clear floated sound image to prevent overlap, and correct gallery link path

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -74,25 +74,25 @@ title: Home
   </article>
 </section>
 
-<section id="sound-experiments" class="block">
+<section id="sound-experiments" class="container section-pad">
   <h2>Sound Experiments</h2>
   <figure class="sound-thumb">
     <img src="https://cdn.midjourney.com/86fd5d11-5a36-4b79-9ed2-a5a94fa81939/0_2.png"
          alt="Vintage microphone with subtle Palestinian embroidery pattern"
          loading="lazy" decoding="async" width="800" height="800" />
   </figure>
-  <ul class="music-list">
-    <li>
-      <strong>Forgotten Sparks</strong> — marimba pulses, evolving pads,
-      faint AM-radio snippets. Mood: subtle binaural echoes.
-      <a href="https://suno.com/s/JUT6IYjmiTbpyjiu">Listen on Suno</a>
-    </li>
-    <li>
-      <strong>Dreamcatcher Glow</strong> — lo-fi lullaby, warm tape
-      saturation, nostalgic vinyl crackle &amp; distant children's laughter.
-      <a href="https://suno.com/s/0EFHyII8YjDHrPdg">Listen on Suno</a>
-    </li>
-  </ul>
+  <div class="suno-grid">
+    <article class="suno-card">
+      <h3>Forgotten Sparks</h3>
+      <p>Marimba pulses, evolving pads, faint AM‑radio snippets. Mood: subtle binaural echoes.</p>
+      <a class="btn-suno" href="https://suno.com/s/JUT6IYjmiTbpyjiu" target="_blank" rel="noopener">Listen on Suno</a>
+    </article>
+    <article class="suno-card">
+      <h3>Dreamcatcher Glow</h3>
+      <p>Lo‑fi lullaby, warm tape saturation, nostalgic vinyl crackle &amp; distant children's laughter.</p>
+      <a class="btn-suno" href="https://suno.com/s/0EFHyII8YjDHrPdg" target="_blank" rel="noopener">Listen on Suno</a>
+    </article>
+  </div>
 </section>
 
 
@@ -115,7 +115,7 @@ title: Home
            loading="lazy" decoding="async" />
     </a>
   </div>
-  <p class="more-link"><a href="/Tamer-Portfolio/media/">See more in the full gallery →</a></p>
+  <p class="more-link"><a href="/Tamer-Portfolio/gallery/">See more in the full gallery →</a></p>
 </section>
 <!-- END: Artistic Snapshots (updated) -->
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -200,3 +200,30 @@ footer .social-icons a img {
 @media (min-width: 900px){
   .sound-thumb{ float:right; width: 34%; margin-left: 1rem; }
 }
+
+/* Sound Experiments layout */
+#sound-experiments::after { content: ""; display: block; clear: both; }
+.sound-thumb { margin-bottom: 1rem; }
+
+/* Suno cards */
+.suno-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+@media (max-width: 900px) { .suno-grid { grid-template-columns: 1fr; } }
+.suno-card {
+  background: #1c1c1c;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 6px 18px rgba(0,0,0,.15);
+}
+.suno-card h3 { margin: 0 0 .35rem; font-size: 1.1rem; }
+.suno-card p { margin: 0 0 .6rem; color: #cfcfcf; }
+.btn-suno {
+  display: inline-block;
+  padding: .55rem 1rem;
+  border-radius: 999px;
+  background: var(--olive);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+.btn-suno:hover { opacity: .9; }


### PR DESCRIPTION
## Summary
- Replace Sound Experiments list with Suno card grid and add section id and spacing.
- Add clearfix for floated sound thumbnail and style new Suno cards.
- Point "See more in the full gallery" link to `/gallery/`.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68974b19f3a8832296f89dd26effd3f3