### PR TITLE
feat(music): redesign page into categorized Suno cards

### DIFF
--- a/src/music.njk
+++ b/src/music.njk
@@ -3,16 +3,124 @@ layout: page.njk
 title: Music
 ---
 
-<h1>AI-Composed Soundscapes</h1>
-<p>This page curates instrumental pieces generated with Suno AI. Feel free to download, share, or request a custom score.</p>
-<ul class="music-list">
-  <li>
-    <strong>Healing in Stasis</strong> — tibetan bowls, atmospheric pads. <a href="https://suno.com/s/aYr8WVp8Zydp6R9v">Listen on Suno</a>
-  </li>
-  <li>
-    <strong>كم كنتي وحدك</strong> — nostalgic oud melody, daf textures. <a href="https://suno.com/s/MiaKO6Npkw1ykyBl">Listen on Suno</a>
-  </li>
-  <li>
-    <strong>Dabke</strong> — lively 6/8 groove with children’s choir. <a href="https://suno.com/s/imNYcMWjluAcaYyE">Listen on Suno</a>
-  </li>
-</ul>
+<section class="container section-pad" aria-labelledby="music-index">
+  <h1 id="music-index">Music</h1>
+  <p class="lede">AI‑composed soundscapes and songs — curated by mood and style. Tap a card to listen on Suno.</p>
+
+  <!-- Quick nav -->
+  <nav class="music-nav">
+    <a href="#summer">Summer Vibes</a>
+    <a href="#relax">Relaxation & Calm</a>
+    <a href="#emotion">Emotional & Nostalgic</a>
+    <a href="#rap">Rap & Fusion</a>
+    <a href="#canaanite">Canaanite Phonetics</a>
+    <a href="#folk">Arabic Folk & Acoustic</a>
+    <a href="#healing">Healing & Ambient</a>
+    <a href="#experimental">Experimental & Electronic</a>
+    <a href="#unsorted">Unsorted / New Drafts</a>
+  </nav>
+
+  <!-- Summer Vibes -->
+  <section id="summer" class="music-group">
+    <h2>Summer Vibes</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Summer Music I</h3><a class="btn-suno" href="https://suno.com/s/PygzVoPOl0XkzZLs" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Summer Music II</h3><a class="btn-suno" href="https://suno.com/s/8qKZAGzttwRbsZ3W" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Relaxation & Calm -->
+  <section id="relax" class="music-group">
+    <h2>Relaxation & Calm</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Relaxing Music</h3><a class="btn-suno" href="https://suno.com/s/ccTwyoNG2Shb1QgI" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Calm & Catchy</h3><a class="btn-suno" href="https://suno.com/s/Pd6yFvryy7CkbIhV" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Calming Music</h3><a class="btn-suno" href="https://suno.com/s/bK7i1o8tV8DuYkPM" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Turkish Calm Music</h3><a class="btn-suno" href="https://suno.com/s/cKBHoqO8JBfe9UJX" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Ethereal Folk / Female Humming</h3><a class="btn-suno" href="https://suno.com/s/0N2KgWdUwAMdjsSp" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Evening Hush</h3><a class="btn-suno" href="https://suno.com/s/Fwh02KWh9O8L4LQD" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Emotional & Nostalgic -->
+  <section id="emotion" class="music-group">
+    <h2>Emotional & Nostalgic</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Emotional Song</h3><a class="btn-suno" href="https://suno.com/s/8hFfLpsSXmXl2Wve" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Nostalgic Music I</h3><a class="btn-suno" href="https://suno.com/s/5Tzs7HGqxM1QvUUJ" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Nostalgic Music II</h3><a class="btn-suno" href="https://suno.com/s/ms0OCAiuT8sQZ9j4" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Nostalgic Middle East</h3><a class="btn-suno" href="https://suno.com/s/rTHZfqruCDZF4RWf" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Rap & Fusion -->
+  <section id="rap" class="music-group">
+    <h2>Rap & Fusion</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Arabic Rap</h3><a class="btn-suno" href="https://suno.com/s/wWPwjbW86etBQl37" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Mix: Arabic + Electronic</h3><a class="btn-suno" href="https://suno.com/s/liV3IwoMuWXhonYQ" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Mix: Arabic Instruments</h3><a class="btn-suno" href="https://suno.com/s/JvAaMoqqAXWdnaXM" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Canaanite Phonetics -->
+  <section id="canaanite" class="music-group">
+    <h2>Canaanite Inspired Phonetics</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Ancient Whispers</h3><a class="btn-suno" href="https://suno.com/s/kQhY8O7MDhVUfeTP" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Canaanite Phonetics I</h3><a class="btn-suno" href="https://suno.com/s/FWXnl3kVOoigdMCC" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Canaanite Phonetics II</h3><a class="btn-suno" href="https://suno.com/s/F4AIaXvUaFiMy0cV" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Canaanite Phonetics III</h3><a class="btn-suno" href="https://suno.com/s/kTneYtfgyvKI5MbZ" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Canaanite Phonetics IV</h3><a class="btn-suno" href="https://suno.com/s/TeteqUVjs1DcYYDA" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Modern Canaanite Phonetics</h3><a class="btn-suno" href="https://suno.com/s/9OGJX2QxIhDj6KJf" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Arabic Folk & Acoustic -->
+  <section id="folk" class="music-group">
+    <h2>Arabic Folk & Acoustic</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Acoustic Arabic Folk</h3><a class="btn-suno" href="https://suno.com/s/zL9CGJLCWJaJoGeQ" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Kitchen Laughs</h3><a class="btn-suno" href="https://suno.com/s/FivqpUInr2JZKSfq" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Healing & Ambient -->
+  <section id="healing" class="music-group">
+    <h2>Healing & Ambient</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Healing Music</h3><a class="btn-suno" href="https://suno.com/s/8k2wRcV7ZTPQE4cM" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Nay Healing Music</h3><a class="btn-suno" href="https://suno.com/s/zx2O4Y4JrfF8jIru" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Experimental & Electronic -->
+  <section id="experimental" class="music-group">
+    <h2>Experimental & Electronic</h2>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Electro World Fusion</h3><a class="btn-suno" href="https://suno.com/s/s6eXkG49AuvUR895" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Glitch Music</h3><a class="btn-suno" href="https://suno.com/s/UaFYKMxExra29R9U" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Jazztronica</h3><a class="btn-suno" href="https://suno.com/s/72D90BABdj5d7w4g" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+
+  <!-- Unsorted / New Drafts (unique links only) -->
+  <section id="unsorted" class="music-group">
+    <h2>Unsorted / New Drafts</h2>
+    <p class="note">Placeholders — we’ll label these after reviewing Suno descriptions.</p>
+    <div class="suno-grid music">
+      <article class="suno-card"><h3>Track A</h3><a class="btn-suno" href="https://suno.com/s/Zv2awMWmqyRr7hea" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track B</h3><a class="btn-suno" href="https://suno.com/s/wqImReM1HvWMdKwV" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track C</h3><a class="btn-suno" href="https://suno.com/s/UcaT7B6jSt2Tl9F3" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track D</h3><a class="btn-suno" href="https://suno.com/s/lVfbglJeh5iYpWRU" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track E</h3><a class="btn-suno" href="https://suno.com/s/AdHLkZJ4oKLWIaNF" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track F</h3><a class="btn-suno" href="https://suno.com/s/JHn8WzDDnbxS7jpQ" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track G</h3><a class="btn-suno" href="https://suno.com/s/QqhFSjX4jucLfdxU" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track H</h3><a class="btn-suno" href="https://suno.com/s/MiaKO6Npkw1ykyBl" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track I</h3><a class="btn-suno" href="https://suno.com/s/tpnTDJf6UAXxI9N5" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track J</h3><a class="btn-suno" href="https://suno.com/s/8PgpObZ8DK604Anj" target="_blank" rel="noopener">Listen on Suno</a></article>
+      <article class="suno-card"><h3>Track K</h3><a class="btn-suno" href="https://suno.com/s/BXlFtWUMToJG6K4K" target="_blank" rel="noopener">Listen on Suno</a></article>
+    </div>
+  </section>
+</section>
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,3 +227,14 @@ footer .social-icons a img {
   font-weight: 600;
 }
 .btn-suno:hover { opacity: .9; }
+/* Music page layout */
+.suno-grid.music { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 1100px){ .suno-grid.music { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px){ .suno-grid.music { grid-template-columns: 1fr; } }
+.music-group { margin: 2.5rem 0; }
+.music-group > h2 { margin-bottom: .75rem; }
+.lede { color: #cfcfcf; margin-bottom: 1rem; }
+.music-nav { display:flex; flex-wrap:wrap; gap:.5rem; margin: .5rem 0 1.5rem; }
+.music-nav a { padding:.35rem .7rem; border:1px solid rgba(255,255,255,.12); border-radius:999px; text-decoration:none; color:#eaeaea; }
+.music-nav a:hover { background: rgba(255,255,255,.06); }
+.note { color:#bdbdbd; margin-bottom:.5rem; }


### PR DESCRIPTION
## Summary
- replace Music page list with categorized Suno cards and quick-nav chips
- extend styles for 3-column music grid, group spacing, and nav chips

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68975c825a388322a48d8a8509510cde