### PR TITLE
feat(media): thumbnail grid + inline embed on click

### DIFF
--- a/docs/media/index.html
+++ b/docs/media/index.html
@@ -26,76 +26,44 @@
     
 <h1>Media</h1>
 
-
-  <article class="media-card">
-    <h2><a href="/content/media/ai-youth-session/">AI Youth Session Video</a></h2>
-    <p>Recording of a youth AI workshop session, discussing the future of AI and its impact on society.
-</p>
-    
-      <div class="video-wrapper">
-        <iframe
-          width="560"
-          height="315"
-          src="https://drive.google.com/file/d/1jGR-P_EeVjXBMkVphaERreJLbpORcQu0/preview"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-      </div>
-    
-  </article>
-
-  <article class="media-card">
-    <h2><a href="/content/media/echoes-of-the-land/">Echoes of the Land – A Song from the Heart of Palestine</a></h2>
-    <p>A song from the heart of Palestine, blending traditional melodies with AI‑generated arrangements.
-</p>
-    
-      <div class="video-wrapper">
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/o5f5cjZw_j8"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-      </div>
-    
-  </article>
-
-  <article class="media-card">
-    <h2><a href="/content/media/mona-lisa-glitch-mode/">Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos</a></h2>
-    <p>An experimental short film exploring the chaos of AI glitch aesthetics using the Mona Lisa as a muse.
-</p>
-    
-      <div class="video-wrapper">
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/TcxHhyMLvfo"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-      </div>
-    
-  </article>
-
-  <article class="media-card">
-    <h2><a href="/content/media/ana-al-ard/">أنا الأرض: قصيدة مصوّرة على لسان فلسطين</a></h2>
-    <p>قصيدة مصوّرة تحيي قصيدة محمود درويش &quot;أنا الأرض&quot;، مستخدمة الذكاء الاصطناعي لنسج صورة وصوت يحاكيان روح فلسطين.
-</p>
-    
-      <div class="video-wrapper">
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/dqGQJQ1jvHg"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-      </div>
-    
-  </article>
+<section class="container section-pad media-hero">
+  <header class="section-head">
+    <h1 class="page-title">Media & Reels</h1>
+    <p class="page-kicker">Fast thumbnails. Click to play inline.</p>
+  </header>
+</section>
 
 
+
+<section class="container section-pad">
+  <div class="video-grid">
+    
+  </div>
+</section>
+
+<script>
+(function(){
+  const qsa = (s)=>Array.from(document.querySelectorAll(s));
+  qsa('.video-card .thumb').forEach(btn => {
+    btn.addEventListener('click', ()=>{
+      const card = btn.closest('.video-card');
+      const id = card && card.getAttribute('data-ytid');
+      const wrap = card && card.querySelector('.player-wrap');
+      if(!id || !wrap) return;
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://www.youtube.com/embed/${id}?autoplay=1&rel=0&modestbranding=1&playsinline=1`;
+      iframe.title = 'YouTube player';
+      iframe.setAttribute('allow','accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share');
+      iframe.allowFullscreen = true;
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      wrap.innerHTML='';
+      wrap.appendChild(iframe);
+      card.classList.add('is-playing');
+    });
+  });
+})();
+</script>
 
   </main>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -249,3 +249,21 @@ footer .social-icons a img {
 .prose{ max-width: 65ch; }
 .bullets{ padding-left: 1.1rem; display: grid; gap: .5rem; }
 .bullets li{ line-height: 1.55; }
+
+/* ===== Media Grid (Step 1) ===== */
+:root{ --olive: var(--olive, #6a7f4e); }
+.media-hero .page-title{ margin:0 0 .25rem; font-size: clamp(1.6rem, 2.5vw, 2rem); }
+.media-hero .page-kicker{ color:#bbb; max-width:65ch; }
+
+.video-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; }
+@media (max-width: 1000px){ .video-grid{ grid-template-columns: repeat(2, 1fr);} }
+@media (max-width: 640px){ .video-grid{ grid-template-columns: 1fr; } }
+
+.video-card{ display:grid; gap:.6rem; background:#111; color:#eee; border:1px solid rgba(255,255,255,.06); border-radius:16px; padding:.6rem; box-shadow:0 6px 18px rgba(0,0,0,.35); }
+.video-card .player-wrap{ position:relative; width:100%; aspect-ratio:16/9; background:#000; border-radius:12px; overflow:hidden; }
+.video-card .thumb{ position:absolute; inset:0; display:grid; place-items:end start; cursor:pointer; }
+.video-card img{ width:100%; height:100%; object-fit:cover; display:block; }
+.play-badge{ margin:0 0 12px 12px; background:rgba(0,0,0,.75); color:#fff; padding:.25rem .45rem; border-radius:999px; font-weight:700; font-size:.9rem; letter-spacing:.02em; }
+.video-card .meta{ display:grid; gap:.35rem; }
+.video-card .v-title{ margin:0; font-size:1rem; line-height:1.4; border-left:6px solid var(--olive); padding-left:.6rem; color:#eaeaea; }
+.video-card .v-desc{ margin:0; color:#cfcfcf; }

--- a/src/_data/media.json
+++ b/src/_data/media.json
@@ -1,0 +1,14 @@
+{
+  "videos": [
+    { "url": "https://youtu.be/L66kKVmgZRI" },
+    { "url": "https://youtu.be/_zTTKywCMu4" },
+    { "url": "https://youtu.be/ZvbIeKdasOc" },
+    { "url": "https://youtu.be/hrYES6lzX9E" },
+    { "url": "https://youtu.be/T64Vv0Opdfs" },
+    { "url": "https://youtu.be/T55aC2muItM" },
+    { "url": "https://youtu.be/o5f5cjZw_j8" },
+    { "url": "https://youtu.be/hjLWd6J86U8" },
+    { "url": "https://youtu.be/TcxHhyMLvfo" },
+    { "url": "https://youtu.be/dqGQJQ1jvHg" }
+  ]
+}

--- a/src/media.njk
+++ b/src/media.njk
@@ -1,23 +1,73 @@
 ---
 layout: page.njk
 title: Media
+permalink: /media/index.html
 ---
 
-{% for item in collections.media %}
-  <article class="media-card">
-    <h2><a href="{{ item.url }}">{{ item.data.title }}</a></h2>
-    <p>{{ item.data.excerpt }}</p>
-    {% if item.data.embed_url %}
-      <div class="video-wrapper">
-        <iframe
-          width="560"
-          height="315"
-          src="{{ item.data.embed_url | youtubeEmbed }}"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-      </div>
-    {% endif %}
-  </article>
-{% endfor %}
+<section class="container section-pad media-hero">
+  <header class="section-head">
+    <h1 class="page-title">Media & Reels</h1>
+    <p class="page-kicker">Fast thumbnails. Click to play inline.</p>
+  </header>
+</section>
 
+{% set items = media.videos | default([]) %}
+
+<section class="container section-pad">
+  <div class="video-grid">
+    {% for video in items %}
+      {% set id = (video.url or '')
+        | replace('https://www.youtube.com/watch?v=', '')
+        | replace('http://www.youtube.com/watch?v=', '')
+        | replace('https://youtu.be/', '')
+        | replace('http://youtu.be/', '')
+        | split('&') | first
+      %}
+      {% if id %}
+        {% set title = video.title or id %}
+        {% set desc = video.desc or '' %}
+        {% set thumb = 'https://i.ytimg.com/vi/' + id + '/hqdefault.jpg' %}
+
+        <article class="video-card" data-ytid="{{ id }}">
+          <div class="player-wrap">
+            <button class="thumb" type="button" aria-label="Play {{ title }}">
+              <img src="{{ thumb }}" alt="Thumbnail: {{ title }}" loading="lazy" />
+              <span class="play-badge" aria-hidden="true">▶</span>
+            </button>
+          </div>
+          <div class="meta">
+            <h3 class="v-title">{{ title }}</h3>
+            {% if desc %}<p class="v-desc">{{ desc }}</p>{% endif %}
+          </div>
+          <noscript>
+            <p><a href="https://www.youtube.com/watch?v={{ id }}" target="_blank" rel="noopener">Open on YouTube</a></p>
+          </noscript>
+        </article>
+      {% endif %}
+    {% endfor %}
+  </div>
+</section>
+
+<script>
+(function(){
+  const qsa = (s)=>Array.from(document.querySelectorAll(s));
+  qsa('.video-card .thumb').forEach(btn => {
+    btn.addEventListener('click', ()=>{
+      const card = btn.closest('.video-card');
+      const id = card && card.getAttribute('data-ytid');
+      const wrap = card && card.querySelector('.player-wrap');
+      if(!id || !wrap) return;
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://www.youtube.com/embed/${id}?autoplay=1&rel=0&modestbranding=1&playsinline=1`;
+      iframe.title = 'YouTube player';
+      iframe.setAttribute('allow','accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share');
+      iframe.allowFullscreen = true;
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      wrap.innerHTML='';
+      wrap.appendChild(iframe);
+      card.classList.add('is-playing');
+    });
+  });
+})();
+</script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -249,3 +249,21 @@ footer .social-icons a img {
 .prose{ max-width: 65ch; }
 .bullets{ padding-left: 1.1rem; display: grid; gap: .5rem; }
 .bullets li{ line-height: 1.55; }
+
+/* ===== Media Grid (Step 1) ===== */
+:root{ --olive: var(--olive, #6a7f4e); }
+.media-hero .page-title{ margin:0 0 .25rem; font-size: clamp(1.6rem, 2.5vw, 2rem); }
+.media-hero .page-kicker{ color:#bbb; max-width:65ch; }
+
+.video-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; }
+@media (max-width: 1000px){ .video-grid{ grid-template-columns: repeat(2, 1fr);} }
+@media (max-width: 640px){ .video-grid{ grid-template-columns: 1fr; } }
+
+.video-card{ display:grid; gap:.6rem; background:#111; color:#eee; border:1px solid rgba(255,255,255,.06); border-radius:16px; padding:.6rem; box-shadow:0 6px 18px rgba(0,0,0,.35); }
+.video-card .player-wrap{ position:relative; width:100%; aspect-ratio:16/9; background:#000; border-radius:12px; overflow:hidden; }
+.video-card .thumb{ position:absolute; inset:0; display:grid; place-items:end start; cursor:pointer; }
+.video-card img{ width:100%; height:100%; object-fit:cover; display:block; }
+.play-badge{ margin:0 0 12px 12px; background:rgba(0,0,0,.75); color:#fff; padding:.25rem .45rem; border-radius:999px; font-weight:700; font-size:.9rem; letter-spacing:.02em; }
+.video-card .meta{ display:grid; gap:.35rem; }
+.video-card .v-title{ margin:0; font-size:1rem; line-height:1.4; border-left:6px solid var(--olive); padding-left:.6rem; color:#eaeaea; }
+.video-card .v-desc{ margin:0; color:#cfcfcf; }


### PR DESCRIPTION
## Summary
- replace `media.njk` with inline-playing thumbnail grid
- add `/src/_data/media.json` video list
- append media grid styles to `styles.css`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a33e80aa48322b3e95ba8fb13cb4d