### PR TITLE
feat: refresh contact page visuals

### DIFF
--- a/src/contact.njk
+++ b/src/contact.njk
@@ -5,7 +5,7 @@ permalink: /contact/index.html
 description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
 ---
 
-{# --- Schema.org for better SEO presence --- #}
+{# SEO: schema.org Person #}
 <script type="application/ld+json">
 {
   "@context":"https://schema.org",
@@ -25,9 +25,9 @@ description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
 </script>
 
 <section class="container section-pad contact-page">
-  <header class="contact-hero">
+  <header class="contact-hero pro-hero">
     <h1>Let’s work together</h1>
-    <p class="lead">Workshops, consulting, creative direction, or just say marhaba 👋</p>
+    <p class="lead">Workshops, consulting, creative direction — or just say marhaba 👋</p>
   </header>
 
   <!-- Primary actions -->
@@ -35,9 +35,9 @@ description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
     <article class="contact-card">
       <div class="cc-head">
         <div class="cc-icon" aria-hidden="true">
-          <!-- mail icon -->
-          <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" role="img" aria-label="Email icon">
-            <path d="M2 6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v.4l-10 6-10-6V6Zm0 2.2V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8.2l-9.4 5.6a2 2 0 0 1-2.2 0L2 8.2Z"/>
+          <!-- Email icon -->
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" role="img" aria-label="Email">
+            <path d="M2 6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v.3l-10 6-10-6V6Zm0 2.3V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8.3l-9.4 5.5a2 2 0 0 1-2.2 0L2 8.3Z"/>
           </svg>
         </div>
         <h2>Email</h2>
@@ -54,9 +54,9 @@ description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
     <article class="contact-card">
       <div class="cc-head">
         <div class="cc-icon" aria-hidden="true">
-          <!-- whatsapp icon -->
-          <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" role="img" aria-label="WhatsApp icon">
-            <path d="M.5 11.8C.5 5.8 5.4.9 11.4.9S22.3 5.8 22.3 11.8c0 6-4.9 10.9-10.9 10.9-1.9 0-3.7-.5-5.3-1.4l-5.6 1.5 1.5-5.4A10.8 10.8 0 0 1 .5 11.8Zm10.9-9.1C6.1 2.7 2 6.8 2 11.8c0 2 .6 3.9 1.7 5.5l-1 3.6 3.7-1a9.7 9.7 0 0 0 5 .1c4.7-1.2 8-5.4 8-10.2 0-5-4.1-9.1-9.1-9.1Zm4.6 12.4c-.2-.1-1.4-.7-1.6-.8-.2-.1-.4-.1-.5.1-.1.2-.6.8-.7.9-.1.1-.3.1-.5 0-.2-.1-.9-.3-1.7-1-.6-.5-1-1.2-1.1-1.4-.1-.2 0-.3.1-.4l.3-.3c.1-.1.1-.2.2-.3.1-.1.1-.2.2-.3.1-.1.1-.2 0-.4l-.8-1.9c-.2-.5-.4-.4-.6-.4h-.5c-.2 0-.4.1-.5.2-.2.2-.7.7-.7 1.8 0 1 .7 1.9.8 2 .1.1 1.5 2.4 3.7 3.3 2.3.9 2.3.6 2.7.6.4 0 1.4-.5 1.6-1.1.2-.6.2-1 .2-1.1 0-.1-.1-.1-.2-.2Z"/>
+          <!-- WhatsApp icon -->
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" role="img" aria-label="WhatsApp">
+            <path d="M.8 11.9C.8 5.6 5.9.6 12.1.6s11.2 5 11.2 11.3S18.4 23.1 12.1 23.1c-2 0-4-.5-5.7-1.5l-6 1.6 1.6-5.8A11.2 11.2 0 0 1 .8 11.9Zm11.3-9.3A9.3 9.3 0 0 0 2.7 11.9c0 2 .6 3.9 1.8 5.5l-1 3.8 3.9-1a10.4 10.4 0 0 0 10.1-1.8 9.3 9.3 0 0 0-4.4-16.8Zm4.8 12.8c-.2 0-1.5-.7-1.7-.9-.2-.1-.4-.1-.5.1l-.7.9c-.1.1-.3.1-.5 0s-1-.3-1.8-1c-.6-.5-1.1-1.3-1.2-1.5-.1-.2 0-.3.1-.4l.3-.3c.1-.1.2-.2.2-.3s.1-.2.2-.3 0-.2 0-.4l-.9-2c-.2-.5-.4-.4-.6-.4h-.5c-.2 0-.4.1-.5.2-.2.2-.8.8-.8 1.9s.7 2 .9 2.2c.1.1 1.6 2.6 4 3.5 2.4 1 2.5.7 2.9.6.5-.1 1.5-.6 1.7-1.2.2-.6.2-1 .2-1.1 0-.1-.1-.1-.2-.2Z"/>
           </svg>
         </div>
         <h2>WhatsApp</h2>
@@ -69,51 +69,104 @@ description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
         <button class="btn btn-ghost js-copy" data-copy="+970 599 797 245" aria-label="Copy WhatsApp number">Copy</button>
       </div>
       <div class="qr-wrap">
-        <!-- Optional QR (auto-generated). Replace size if you want larger QR -->
         <img src="https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=https%3A%2F%2Fwa.me%2F970599797245" alt="WhatsApp QR code to chat with Tamer" width="160" height="160" loading="lazy">
       </div>
     </article>
   </div>
 
-  <!-- Socials grid -->
+  <!-- Socials grid with icons + avatars -->
   <section class="contact-socials">
     <h3>Find me online</h3>
     <div class="social-grid">
-      <a class="social-card" href="https://www.facebook.com/teamo1985/" target="_blank" rel="noopener" aria-label="Facebook">
-        <span class="sc-title">Facebook</span>
-        <span class="sc-handle">@teamo1985</span>
+      <!-- Facebook -->
+      <a class="social-card sc--facebook" href="https://www.facebook.com/teamo1985/" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M22 12.1A10 10 0 1 0 10.6 22v-7h-2.1v-2.9h2.1V9.5c0-2 1.2-3.1 3-3.1.9 0 1.9.2 1.9.2v2.1h-1.1c-1 0-1.3.6-1.3 1.2v1.5h2.3l-.4 2.9h-1.9V22A10 10 0 0 0 22 12.1"/></svg>
+          </span>
+          <img class="sc-avatar" src="https://unavatar.io/facebook/teamo1985" alt="Facebook avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">Facebook</span>
+          <span class="sc-handle">@teamo1985</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
-      <a class="social-card" href="https://x.com/TamerTeamo" target="_blank" rel="noopener" aria-label="X (Twitter)">
-        <span class="sc-title">X (Twitter)</span>
-        <span class="sc-handle">@TamerTeamo</span>
+
+      <!-- X -->
+      <a class="social-card sc--x" href="https://x.com/TamerTeamo" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M18.2 2H21l-7 8.2L22.6 22H16L10.9 15.9 5 22H2.2l7.6-8.9L1.1 2h6.7l4.8 5.9L18.2 2Zm-2.1 18h1.1L7 4H5.8l10.3 16Z"/></svg></span>
+          <img class="sc-avatar" src="https://unavatar.io/twitter/TamerTeamo" alt="X avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">X (Twitter)</span>
+          <span class="sc-handle">@TamerTeamo</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
-      <a class="social-card" href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" rel="noopener" aria-label="TikTok">
-        <span class="sc-title">TikTok</span>
-        <span class="sc-handle">@ai_visionary_tm</span>
+
+      <!-- TikTok -->
+      <a class="social-card sc--tiktok" href="https://www.tiktok.com/@ai_visionary_tm" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M16.8 2c.5 2 1.8 3.7 3.6 4.6 1 .6 2 .9 3.1 1v3.1c-1.7-.1-3.3-.6-4.8-1.4v6.9a6.9 6.9 0 1 1-6.9-6.9c.4 0 .8 0 1.2.1v3.3a3.6 3.6 0 1 0 2.4 3.4V2h1.4Z"/></svg></span>
+          <img class="sc-avatar" src="https://unavatar.io/tiktok/ai_visionary_tm" alt="TikTok avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">TikTok</span>
+          <span class="sc-handle">@ai_visionary_tm</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
-      <a class="social-card" href="https://www.youtube.com/@TamerAI-e5i" target="_blank" rel="noopener" aria-label="YouTube">
-        <span class="sc-title">YouTube</span>
-        <span class="sc-handle">@TamerAI-e5i</span>
+
+      <!-- YouTube -->
+      <a class="social-card sc--youtube" href="https://www.youtube.com/@TamerAI-e5i" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M23 7.5a4 4 0 0 0-2.8-2.8C18 4.2 12 4.2 12 4.2s-6 0-8.2.5A4 4 0 0 0 1 7.5 41 41 0 0 0 .5 12c0 1.5.5 4.5.5 4.5a4 4 0 0 0 2.8 2.8c2.2.5 8.2.5 8.2.5s6 0 8.2-.5a4 4 0 0 0 2.8-2.8s.5-3 .5-4.5-.5-4.5-.5-4.5ZM9.8 14.8V9.2l5.4 2.8-5.4 2.8Z"/></svg></span>
+          <img class="sc-avatar" src="https://unavatar.io/youtube/@TamerAI-e5i" alt="YouTube avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">YouTube</span>
+          <span class="sc-handle">@TamerAI-e5i</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
-      <a class="social-card" href="https://substack.com/@snoopman?utm_campaign=profile&utm_medium=profile-page" target="_blank" rel="noopener" aria-label="Substack">
-        <span class="sc-title">Substack</span>
-        <span class="sc-handle">@snoopman</span>
+
+      <!-- Substack -->
+      <a class="social-card sc--substack" href="https://substack.com/@snoopman?utm_campaign=profile&utm_medium=profile-page" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M3 4h18v2H3V4Zm0 4h18v2H3V8Zm0 3h18v9l-9-4-9 4v-9Z"/></svg></span>
+          <img class="sc-avatar" src="https://unavatar.io/substack/snoopman" alt="Substack avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">Substack</span>
+          <span class="sc-handle">@snoopman</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
-      <a class="social-card" href="https://www.instagram.com/tamerpalestine/" target="_blank" rel="noopener" aria-label="Instagram">
-        <span class="sc-title">Instagram</span>
-        <span class="sc-handle">@tamerpalestine</span>
+
+      <!-- Instagram -->
+      <a class="social-card sc--instagram" href="https://www.instagram.com/tamerpalestine/" target="_blank" rel="noopener">
+        <div class="sc-left">
+          <span class="sc-ico" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm5 5.8a5.2 5.2 0 1 0 0 10.4 5.2 5.2 0 0 0 0-10.4Zm6.1-.9a1.2 1.2 0 1 0 0 2.4 1.2 1.2 0 0 0 0-2.4Z"/></svg></span>
+          <img class="sc-avatar" src="https://unavatar.io/instagram/tamerpalestine" alt="Instagram avatar" width="40" height="40" loading="lazy">
+        </div>
+        <div class="sc-body">
+          <span class="sc-title">Instagram</span>
+          <span class="sc-handle">@tamerpalestine</span>
+        </div>
+        <span class="sc-arrow" aria-hidden="true">↗</span>
       </a>
     </div>
   </section>
 
-  <!-- Optional form (disabled by default). To enable, set action to Formspree/Netlify endpoint -->
+  <!-- Optional form (kept disabled) -->
   <section class="contact-form">
     <h3>Or send a quick note</h3>
     <form class="form" method="POST" action="" data-disabled="true">
       <input type="text" name="name" placeholder="Your name" required>
       <input type="email" name="email" placeholder="Your email" required>
       <textarea name="message" rows="5" placeholder="Tell me about your project"></textarea>
-      <!-- Honeypot -->
       <input type="text" name="_gotcha" style="display:none" tabindex="-1" autocomplete="off">
       <button class="btn btn-primary" type="submit" disabled title="Form disabled—use Email or WhatsApp above">Send</button>
       <p class="form-note">Prefer voice notes? WhatsApp is fastest.</p>
@@ -121,6 +174,5 @@ description: "Get in touch with Tamer Mansour — email, WhatsApp, and socials."
   </section>
 </section>
 
-<!-- Page script (uses | url to respect pathPrefix) -->
 <script defer src="{{ '/js/contact.js' | url }}"></script>
 

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -6,6 +6,8 @@
   <title>{{ title }}</title>
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="preconnect" href="https://api.qrserver.com" crossorigin>
+  <link rel="preconnect" href="https://unavatar.io" crossorigin>
+  <link rel="dns-prefetch" href="https://unavatar.io">
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -473,3 +473,79 @@ footer .social-icons a img {
   .contact-page .btn{ color:#111 !important; }
   .contact-card .cc-value a{ color:#111 !important; }
 }
+/* ===== Contact page polish (icons + avatars + brand accents) ===== */
+.pro-hero{
+  background: linear-gradient(180deg, rgba(106,127,78,.18), rgba(106,127,78,.08));
+  border:1px solid rgba(106,127,78,.25);
+  border-radius:16px; padding:1rem; margin-bottom:.6rem;
+}
+
+.contact-card{
+  position:relative;
+  background:#fff; color:#111;
+  border:1px solid #ececec; border-radius:16px; padding:1rem;
+  box-shadow:0 8px 22px rgba(0,0,0,.05);
+}
+.cc-head{ display:flex; align-items:center; gap:.6rem; margin-bottom:.35rem }
+.cc-icon{
+  width:40px; height:40px; display:grid; place-items:center;
+  border-radius:12px; background:rgba(106,127,78,.12); color:var(--olive,#6a7f4e);
+}
+
+.contact-page .btn{ color:#111; }
+.contact-page .btn-primary{ border-color:var(--olive,#6a7f4e); background:rgba(106,127,78,.12) }
+.contact-page .btn-ghost{ background:#fff; border-color:#e3e3e3 }
+
+/* Social grid cards */
+.social-grid{
+  display:grid; gap:.8rem;
+  grid-template-columns: repeat(12, 1fr);
+}
+@media (max-width:1000px){ .social-grid{ grid-template-columns: repeat(8, 1fr) } }
+@media (max-width:720px){ .social-grid{ grid-template-columns: repeat(4, 1fr) } }
+
+.social-card{
+  grid-column: span 6;
+  display:flex; align-items:center; gap:.8rem;
+  text-decoration:none; color:inherit;
+  background:#fff; border:1px solid #ececec; border-radius:16px; padding:.8rem .9rem;
+  box-shadow:0 8px 22px rgba(0,0,0,.05); transition: transform .15s ease, box-shadow .15s ease;
+}
+@media (max-width:720px){ .social-card{ grid-column: span 4 } }
+
+.social-card:hover{ transform: translateY(-2px); box-shadow:0 14px 28px rgba(0,0,0,.08) }
+
+.sc-left{ display:flex; align-items:center; gap:.6rem }
+.sc-ico{
+  width:36px; height:36px; display:grid; place-items:center;
+  border-radius:12px; background:#f4f4f4; color:#111;
+}
+.sc-avatar{
+  width:38px; height:38px; border-radius:50%; object-fit:cover; background:#f1f1f1;
+  border:1px solid #eee;
+}
+.sc-body{ display:flex; flex-direction:column; }
+.sc-title{ font-weight:700; color:#111 }
+.sc-handle{ color:#333; opacity:.95 }
+.sc-arrow{ margin-left:auto; opacity:.6 }
+
+/* Brand color accents per platform */
+.sc--facebook .sc-ico{ background:rgba(24,119,242,.12); color:#1877F2 }
+.sc--x .sc-ico{ background:rgba(0,0,0,.12); color:#111 }
+.sc--tiktok .sc-ico{ background:rgba(0,0,0,.12); color:#111 }
+.sc--youtube .sc-ico{ background:rgba(255,0,0,.12); color:#FF0000 }
+.sc--substack .sc-ico{ background:rgba(255,102,0,.12); color:#FF6600 }
+.sc--instagram .sc-ico{ background:rgba(225,48,108,.12); color:#E1306C }
+
+/* Form fields readable on white */
+.contact-form .form input,
+.contact-form .form textarea{ color:#111; background:#fff; border:1px solid #e3e3e3 }
+.contact-form .form ::placeholder{ color:#777 }
+
+/* Dark-mode override: keep cards readable */
+@media (prefers-color-scheme: dark){
+  .contact-card, .social-card, .contact-card *:not(svg), .social-card *:not(svg){
+    color:#111 !important; background:#fff !important;
+  }
+}
+


### PR DESCRIPTION
## Summary
- revamp contact page with CTA cards and social grid featuring icons and avatars
- polish contact styles and brand accents
- add preconnect for unavatar avatars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97acb3c0c8322bbe48a6ab60ae271