### PR TITLE
feat: add about page and remove legacy about files

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -1,14 +1,160 @@
 ---
 layout: page.njk
 title: About
+permalink: /about/index.html
+description: "Tamer Mansour — Palestinian creative technologist building AI-native stories & systems."
 ---
 
-<p>Tamer Mansour is a Palestinian AI consultant, creator and entrepreneur. His work sits at the intersection of technology, identity and imagination, crafting new narratives that uplift Palestinian stories and empower creators across the globe.</p>
+<section class="about-page" style="--bg-tile-url: url('https://cdn.midjourney.com/d101fa42-20b7-43ac-bba9-9ead7c15086c/0_1.png')">
 
-<h2>Skills</h2>
-<ul>
-  <li>Generative AI &amp; Machine Learning</li>
-  <li>Creative Coding &amp; Multimedia Production</li>
-  <li>Film Direction &amp; Post‑Production</li>
-  <li>Workshops &amp; Consulting for Creative Professionals</li>
-</ul>
+  <header class="about-hero">
+    <div class="about-hero__media">
+      <video class="about-video about-video--desktop" playsinline autoplay muted loop preload="auto" aria-hidden="true">
+        <source src="https://cdn.midjourney.com/video/619aa43b-5e4c-4d92-a608-04343c21b28d/3.mp4" type="video/mp4">
+      </video>
+      <video class="about-video about-video--mobile" playsinline autoplay muted loop preload="auto" aria-hidden="true">
+        <source src="https://cdn.midjourney.com/video/08f9ee34-6928-4f37-8489-7006a4f1e325/2.mp4" type="video/mp4">
+      </video>
+      <div class="about-hero__overlay"></div>
+    </div>
+
+    <div class="about-hero__body container">
+      <h1>I build AI-native stories & systems.</h1>
+      <p class="lead">
+        Palestinian creative technologist from Ramallah. I help teams and artists move from research to prototypes to reels—fast, ethical, bilingual.
+      </p>
+      <div class="btn-row">
+        <a class="btn btn-primary" href="{{ '/contact/' | url }}">Book a call</a>
+        <a class="btn" href="{{ '/media/' | url }}">See my reels</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="about-bio container section-pad">
+    <p>
+      I’m <strong>Tamer Mansour</strong> — AI consultant, creator, and educator. I design AI-native workflows for cultural orgs, startups, and independent creators. 
+      My work blends research (NotebookLM), prompting systems, and visual look-dev to turn messy ideas into shareable prototypes. 
+      I work in Arabic and English, with a quiet Palestinian aesthetic — olive, stone, and a whisper of kufiya.
+    </p>
+  </section>
+
+  <section class="about-lenses container section-pad">
+    <div class="lens">
+      <figure class="lens__media">
+        <img src="https://cdn.midjourney.com/9de756f2-5f10-4406-803b-e44f350f621d/0_2.png" alt="Creator lens — ink and phosphor generative frames" loading="lazy" decoding="async">
+      </figure>
+      <div class="lens__body">
+        <h2>Creator</h2>
+        <ul class="clean-list">
+          <li>Visual poems & look-dev experiments</li>
+          <li>Generative image/video sequences</li>
+        </ul>
+        <a class="btn" href="{{ '/media/' | url }}">Explore media</a>
+      </div>
+    </div>
+
+    <div class="lens">
+      <figure class="lens__media">
+        <img src="https://cdn.midjourney.com/dd8a7cd1-e68a-4eb1-b2b9-757d87ae230b/0_0.png" alt="Consultant lens — isometric system map of creative workflow" loading="lazy" decoding="async">
+      </figure>
+      <div class="lens__body">
+        <h2>Consultant</h2>
+        <ul class="clean-list">
+          <li>Training, sprints, and hands-on prototyping</li>
+          <li>Outcome-focused: leave with a working method</li>
+        </ul>
+        <a class="btn" href="{{ '/training-consulting/' | url }}">Services</a>
+      </div>
+    </div>
+
+    <div class="lens">
+      <figure class="lens__media">
+        <img src="https://cdn.midjourney.com/bf34ee17-97c2-4798-ad08-3ad6cd43c0d8/0_1.png" alt="Researcher lens — atlas collage without readable text" loading="lazy" decoding="async">
+      </figure>
+      <div class="lens__body">
+        <h2>Researcher</h2>
+        <ul class="clean-list">
+          <li>NotebookLM notebooks you can interact with</li>
+          <li>Essays & technical roadmaps for non-engineers</li>
+        </ul>
+        <div class="btn-row">
+          <a class="btn" href="{{ '/research/' | url }}">Research</a>
+          <a class="btn" href="{{ '/blog/' | url }}">Blog</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="about-principles container section-pad">
+    <h2>Principles</h2>
+    <ol class="num-list">
+      <li><strong>Prototype first.</strong> A day of making beats a month of meetings.</li>
+      <li><strong>Human taste, machine speed.</strong> Tools amplify—not replace—judgment.</li>
+      <li><strong>Ethics by design.</strong> Consent, attribution, bias testing.</li>
+      <li><strong>Arabic + English.</strong> Both are first-class citizens.</li>
+      <li><strong>Clarity over noise.</strong> Ship small, often—and improve.</li>
+    </ol>
+  </section>
+
+  <section class="about-origin container section-pad">
+    <h2>Origin</h2>
+    <ul class="origin-list">
+      <li>
+        I came from a mix of filmmaking, community projects, and product experiments.
+        <img class="about-divider" src="https://cdn.midjourney.com/85b5abde-46bb-431f-82a4-0cbef15ee7df/0_2.png" alt="" aria-hidden="true" loading="lazy">
+      </li>
+      <li>
+        When generative tools matured, I shifted to AI-native workflows—research systems, prompt stacks, visual pipelines.
+        <img class="about-divider" src="https://cdn.midjourney.com/85b5abde-46bb-431f-82a4-0cbef15ee7df/0_2.png" alt="" aria-hidden="true" loading="lazy">
+      </li>
+      <li>
+        Today I help teams and artists think clearer and publish faster—bilingually, with taste and care.
+      </li>
+    </ul>
+  </section>
+
+  <section class="about-highlights container section-pad">
+    <ul class="hi-grid">
+      <li><span class="hi-num">10+</span><span class="hi-label">workshops</span></li>
+      <li><span class="hi-num">40+</span><span class="hi-label">prototypes & reels</span></li>
+      <li><span class="hi-num">2</span><span class="hi-label">languages</span></li>
+      <li><span class="hi-num">X</span><span class="hi-label">collaborators</span></li>
+    </ul>
+  </section>
+
+  <section class="about-toolbelt container section-pad">
+    <figure class="toolbelt-fig">
+      <img src="https://cdn.midjourney.com/134484b0-7362-4b0d-8172-01133d632d39/0_1.png" alt="Minimal glyphs row for AI, research, video, audio, code, cloud" loading="lazy" decoding="async">
+    </figure>
+    <p class="toolbelt-note">
+      Current stack (living list): ChatGPT, Gemini, Claude, Grok (as needed) • Midjourney, Runway, Veo 3, Kling • Suno, ElevenLabs • NotebookLM, Docs • Resolve/Premiere, CapCut, ComfyUI • GitHub Pages, Netlify, Supabase, Giscus
+    </p>
+  </section>
+
+  <section class="about-portrait container section-pad">
+    <figure class="portrait-fig">
+      <img src="https://cdn.midjourney.com/47d067dc-d9d6-474d-8405-9f1b46f2c7be/0_2.png" alt="Abstract silhouette portrait, olive + limestone textures" loading="lazy" decoding="async">
+    </figure>
+  </section>
+
+  <section class="about-now container section-pad">
+    <h2>Now</h2>
+    <p>Designing AI-native story workflows for cultural orgs; developing a visual-poetry reel series; writing guides on RAG/NotebookLM for non-engineers.</p>
+  </section>
+
+  <section class="about-cta">
+    <figure class="about-cta__bg">
+      <img src="https://cdn.midjourney.com/20917ee0-3866-4888-95c4-d83e2943e463/0_2.png" alt="Soft sunrise olive gradient with whisper kufiya emboss" loading="lazy" decoding="async">
+    </figure>
+    <div class="about-cta__body container">
+      <h2>Let’s build something.</h2>
+      <div class="btn-row">
+        <a class="btn btn-primary" href="{{ '/contact/' | url }}">Contact</a>
+        <a class="btn" href="{{ '/training-consulting/' | url }}">Services</a>
+        <a class="btn btn-ghost" href="{{ '/media/' | url }}">Media</a>
+      </div>
+    </div>
+  </section>
+
+</section>
+


### PR DESCRIPTION
## Summary
- replace legacy About page with new Nunjucks template powered by Midjourney assets
- remove any leftover legacy About markdown files
- confirm head includes Midjourney preconnect and dns-prefetch hints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab00fea22c8322a1f8b3851ff531d0