### PR TITLE
fix: stabilize colors in Facebook in-app browser

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>About</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/about/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -241,11 +239,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/about/index.html
+++ b/docs/ar/about/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>نبذة</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/about/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -239,11 +237,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/blog/category/يوميات-صناعة/index.html
+++ b/docs/ar/blog/category/يوميات-صناعة/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/ar/blog/category/يوميات-صناعة/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -99,11 +97,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/blog/index.html
+++ b/docs/ar/blog/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>المدونة</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/blog/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -108,11 +106,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/blog/tag/سير-العمل/index.html
+++ b/docs/ar/blog/tag/سير-العمل/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/ar/blog/tag/سير-العمل/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -100,11 +98,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/blog/tag/فيديو-ذكاء-اصطناعي/index.html
+++ b/docs/ar/blog/tag/فيديو-ذكاء-اصطناعي/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/ar/blog/tag/فيديو-ذكاء-اصطناعي/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -100,11 +98,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/contact/index.html
+++ b/docs/ar/contact/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>تواصل</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/contact/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -163,11 +161,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/gallery/index.html
+++ b/docs/ar/gallery/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>المعرض</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/gallery/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -470,11 +468,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/index.html
+++ b/docs/ar/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>الرئيسية</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -222,11 +220,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/media/index.html
+++ b/docs/ar/media/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>الوسائط والريلز</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/media/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -80,14 +78,14 @@
   <div class="art-grid" id="mediaGrid">
     
       
-      <article class="art-card js-video" data-yt="dqGQJQ1jvHg" data-title="I Am the Land — Visual Poem" data-tags="poem,palestine,visual">
+      <article class="art-card js-video" data-yt="dqGQJQ1jvHg" data-title="I Am the Land — Visual Poem (Mahmoud Darwish-inspired)" data-tags="poem,palestine,visual">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/dqGQJQ1jvHg/hqdefault.jpg" alt="I Am the Land — Visual Poem" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/dqGQJQ1jvHg/hqdefault.jpg" alt="I Am the Land — Visual Poem (Mahmoud Darwish-inspired)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">I Am the Land — Visual Poem</h3>
-          <p class="art-desc">A visual poem inspired by Mahmoud Darwish — voice, memory-made imagery, and AI cinematics.</p>
+          <h3 class="art-title">أنا الأرض: قصيدة مصوّرة على لسان فلسطين</h3>
+          <p class="art-desc">قصيدة بصرية بصوتٍ يحاكي محمود درويش؛ صور تولّدها الذاكرة وسينمائيات بالذكاء الاصطناعي تصوغ صوت فلسطين في مونولوج حميم.</p>
           
             <div class="tags">
               
@@ -104,22 +102,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="TcxHhyMLvfo" data-title="Generative Portraits — Motion Study" data-tags="ai-film,portrait,study">
+      <article class="art-card js-video" data-yt="TcxHhyMLvfo" data-title="Mona Lisa Rewired — AI Glitch Journey" data-tags="ai-film,glitch,mona-lisa">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/TcxHhyMLvfo/hqdefault.jpg" alt="Generative Portraits — Motion Study" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/TcxHhyMLvfo/hqdefault.jpg" alt="Mona Lisa Rewired — AI Glitch Journey" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Generative Portraits — Motion Study</h3>
-          <p class="art-desc">Short study in generative motion and portrait texture. Hand-crafted prompts + minimal cuts.</p>
+          <h3 class="art-title">موناليزا بنسخة لا تصلح للجميع — رحلة Glitch بالذكاء الاصطناعي</h3>
+          <p class="art-desc">اختبار حسّي لمدة 3:30 دقائق: عشرات المعالجات الأسلوبية للصورة تحت موسيقى Glitch من Suno. يُنصح بسماعات.</p>
           
             <div class="tags">
               
                 <span class="chip">ai-film</span>
               
-                <span class="chip">portrait</span>
+                <span class="chip">glitch</span>
               
-                <span class="chip">study</span>
+                <span class="chip">mona-lisa</span>
               
             </div>
           
@@ -128,22 +126,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="hjLWd6J86U8" data-title="Memory of Stones — Short Reel" data-tags="reel,palestine,texture">
+      <article class="art-card js-video" data-yt="hjLWd6J86U8" data-title="A Unified Palestinian Message (Veo 3)" data-tags="palestine,veo3,message">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/hjLWd6J86U8/hqdefault.jpg" alt="Memory of Stones — Short Reel" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/hjLWd6J86U8/hqdefault.jpg" alt="A Unified Palestinian Message (Veo 3)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Memory of Stones — Short Reel</h3>
-          <p class="art-desc">Reel exploring stone, dust, and archival textures as living memory.</p>
+          <h3 class="art-title">رسالة فلسطينية موحّدة (Veo 3)</h3>
+          <p class="art-desc">صرخة موحّدة من غزة والضفة والقدس والـ48 والمخيمات والشتات—إنتاج بصري بـVeo 3 وكلمات ومشاعر حقيقية.</p>
           
             <div class="tags">
               
-                <span class="chip">reel</span>
-              
                 <span class="chip">palestine</span>
               
-                <span class="chip">texture</span>
+                <span class="chip">veo3</span>
+              
+                <span class="chip">message</span>
               
             </div>
           
@@ -152,22 +150,24 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="nBkYRVSdio4" data-title="City of Echoes — AI Music Cut" data-tags="music,ai-film,reel">
+      <article class="art-card js-video" data-yt="nBkYRVSdio4" data-title="DNA &amp; the Levant — Are Palestinians Canaanite Descendants? (Podcast)" data-tags="podcast,dna,canaanites,palestine">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/nBkYRVSdio4/hqdefault.jpg" alt="City of Echoes — AI Music Cut" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/nBkYRVSdio4/hqdefault.jpg" alt="DNA &amp; the Levant — Are Palestinians Canaanite Descendants? (Podcast)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">City of Echoes — AI Music Cut</h3>
-          <p class="art-desc">Music-driven visual cut; rhythms guide scenes through light and shadow.</p>
+          <h3 class="art-title">هل الفلسطينيون من سلالة الكنعانيين؟ (بودكاست)</h3>
+          <p class="art-desc">غوص مبسّط في دراسات DNA القديمة (2017–2025) التي تربط الفلسطينيين بالكنعانيين؛ هوية واستمرارية وتفنيد أساطير.</p>
           
             <div class="tags">
               
-                <span class="chip">music</span>
+                <span class="chip">podcast</span>
               
-                <span class="chip">ai-film</span>
+                <span class="chip">dna</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">canaanites</span>
+              
+                <span class="chip">palestine</span>
               
             </div>
           
@@ -176,22 +176,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="4_OvFXOjkWU" data-title="Eyes of Gaza — Microfilm" data-tags="palestine,microfilm,poem">
+      <article class="art-card js-video" data-yt="4_OvFXOjkWU" data-title="Do We Live in a Simulation? — 20 Theories (Podcast)" data-tags="podcast,philosophy,simulation">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/4_OvFXOjkWU/hqdefault.jpg" alt="Eyes of Gaza — Microfilm" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/4_OvFXOjkWU/hqdefault.jpg" alt="Do We Live in a Simulation? — 20 Theories (Podcast)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Eyes of Gaza — Microfilm</h3>
-          <p class="art-desc">Microfilm sequence — glances, rubble, and resilience. Minimal text, strong imagery.</p>
+          <h3 class="art-title">هل نعيش في محاكاة؟ — 20 نظرية (بودكاست)</h3>
+          <p class="art-desc">حلقة NotebookLM تستكشف 20 إطارًا لفهم الواقع—من فرضية المحاكاة إلى الأكوان المتعددة—مع أسئلة وتمارين ذهنية.</p>
           
             <div class="tags">
               
-                <span class="chip">palestine</span>
+                <span class="chip">podcast</span>
               
-                <span class="chip">microfilm</span>
+                <span class="chip">philosophy</span>
               
-                <span class="chip">poem</span>
+                <span class="chip">simulation</span>
               
             </div>
           
@@ -200,20 +200,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="o5f5cjZw_j8" data-title="Echoes of the Land — Song" data-tags="music,palestine">
+      <article class="art-card js-video" data-yt="o5f5cjZw_j8" data-title="Echoes of the Land — Song" data-tags="music,palestine,civilizations">
         <div class="art-thumb">
           <img src="https://i.ytimg.com/vi/o5f5cjZw_j8/hqdefault.jpg" alt="Echoes of the Land — Song" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Echoes of the Land — Song</h3>
-          <p class="art-desc">A song from the heart of Palestine — traditional motifs blended with AI arrangement.</p>
+          <h3 class="art-title">أصداء الأرض — أغنية</h3>
+          <p class="art-desc">رحلة موسيقية عبر حضارات فلسطين—زخارف ولهجات وأزياء تتلاقى في كورسٍ عاطفي واحد.</p>
           
             <div class="tags">
               
                 <span class="chip">music</span>
               
                 <span class="chip">palestine</span>
+              
+                <span class="chip">civilizations</span>
               
             </div>
           
@@ -222,22 +224,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="T55aC2muItM" data-title="Desert Birds — Visual Study" data-tags="study,minimal,reel">
+      <article class="art-card js-video" data-yt="T55aC2muItM" data-title="The Unbroken Palestinian — Rap" data-tags="rap,palestine,resilience">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/T55aC2muItM/hqdefault.jpg" alt="Desert Birds — Visual Study" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/T55aC2muItM/hqdefault.jpg" alt="The Unbroken Palestinian — Rap" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Desert Birds — Visual Study</h3>
-          <p class="art-desc">Minimal shots and grain — studying motion like birds over dunes.</p>
+          <h3 class="art-title">أنا الفلسطيني… اللي ما ينكسر — راب</h3>
+          <p class="art-desc">نشيد صمودٍ خام—كلمات حادّة وإيقاع ثقيل يعبّر عن الألم والنضال والأمل الذي لا ينكسر.</p>
           
             <div class="tags">
               
-                <span class="chip">study</span>
+                <span class="chip">rap</span>
               
-                <span class="chip">minimal</span>
+                <span class="chip">palestine</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">resilience</span>
               
             </div>
           
@@ -246,22 +248,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="T64Vv0Opdfs" data-title="Olive Branch Dreams — Reel" data-tags="olive,reel,visual">
+      <article class="art-card js-video" data-yt="T64Vv0Opdfs" data-title="The Metaphorical Map of Tamer’s Life" data-tags="biography,metaphor,story">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/T64Vv0Opdfs/hqdefault.jpg" alt="Olive Branch Dreams — Reel" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/T64Vv0Opdfs/hqdefault.jpg" alt="The Metaphorical Map of Tamer’s Life" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Olive Branch Dreams — Reel</h3>
-          <p class="art-desc">Olive leaves, fabric patterns, and soft light — a reel about calm resistance.</p>
+          <h3 class="art-title">الخريطة المجازية لحياة تامر</h3>
+          <p class="art-desc">سيرة رمزية: مناظر داخلية وكائنات وعلامات ترسم الطموح والإبداع والتحوّل المتواصل.</p>
           
             <div class="tags">
               
-                <span class="chip">olive</span>
+                <span class="chip">biography</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">metaphor</span>
               
-                <span class="chip">visual</span>
+                <span class="chip">story</span>
               
             </div>
           
@@ -270,20 +272,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="hrYES6lzX9E" data-title="Dawn Over the Hills — Ambient Cut" data-tags="ambient,reel">
+      <article class="art-card js-video" data-yt="hrYES6lzX9E" data-title="Echoes of History — Ibn Sina" data-tags="history,ibn-sina,philosophy">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/hrYES6lzX9E/hqdefault.jpg" alt="Dawn Over the Hills — Ambient Cut" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/hrYES6lzX9E/hqdefault.jpg" alt="Echoes of History — Ibn Sina" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Dawn Over the Hills — Ambient Cut</h3>
-          <p class="art-desc">Ambient visuals at first light — slow camera, long frames.</p>
+          <h3 class="art-title">أصداء التاريخ — ابن سينا</h3>
+          <p class="art-desc">بورتريه تأملي لابن سينا—العلم والطب والفلسفة في مشاهد يومية واقتباسات خالدة.</p>
           
             <div class="tags">
               
-                <span class="chip">ambient</span>
+                <span class="chip">history</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">ibn-sina</span>
+              
+                <span class="chip">philosophy</span>
               
             </div>
           
@@ -292,20 +296,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="ZvbIeKdasOc" data-title="Broken Frame — Experimental Edit" data-tags="experimental,ai-film">
+      <article class="art-card js-video" data-yt="ZvbIeKdasOc" data-title="Echoes of History — Mandela’s Dawn" data-tags="history,mandela,freedom">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/ZvbIeKdasOc/hqdefault.jpg" alt="Broken Frame — Experimental Edit" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/ZvbIeKdasOc/hqdefault.jpg" alt="Echoes of History — Mandela’s Dawn" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Broken Frame — Experimental Edit</h3>
-          <p class="art-desc">Experimental pacing and frame tearing — testing limits of AI motion.</p>
+          <h3 class="art-title">أصداء التاريخ — فجر مانديلا</h3>
+          <p class="art-desc">لحظة هادئة حول يوم الإفراج عن مانديلا—فجر الحرية والطريق الذي تلاه.</p>
           
             <div class="tags">
               
-                <span class="chip">experimental</span>
+                <span class="chip">history</span>
               
-                <span class="chip">ai-film</span>
+                <span class="chip">mandela</span>
+              
+                <span class="chip">freedom</span>
               
             </div>
           
@@ -314,22 +320,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="L66kKVmgZRI" data-title="Sand &amp; Light — Minimal Poetics" data-tags="minimal,poem,visual">
+      <article class="art-card js-video" data-yt="L66kKVmgZRI" data-title="Roots of Resilience — A Journey Through Palestine" data-tags="palestine,heritage,orchestral">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/L66kKVmgZRI/hqdefault.jpg" alt="Sand &amp; Light — Minimal Poetics" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/L66kKVmgZRI/hqdefault.jpg" alt="Roots of Resilience — A Journey Through Palestine" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="تشغيل الفيديو">► شاهد</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Sand &amp; Light — Minimal Poetics</h3>
-          <p class="art-desc">Minimal visual poetics: sand, wind, and soft light in quiet loops.</p>
+          <h3 class="art-title">جذور الصمود — رحلة عبر فلسطين</h3>
+          <p class="art-desc">تحية أوركسترالية غنية بالصورة لإرث فلسطين—من زيتون جنين إلى أمواج غزة وشوارع القدس.</p>
           
             <div class="tags">
               
-                <span class="chip">minimal</span>
+                <span class="chip">palestine</span>
               
-                <span class="chip">poem</span>
+                <span class="chip">heritage</span>
               
-                <span class="chip">visual</span>
+                <span class="chip">orchestral</span>
               
             </div>
           
@@ -361,11 +367,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/music/index.html
+++ b/docs/ar/music/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>الموسيقى</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/music/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -197,11 +195,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/projects/index.html
+++ b/docs/ar/projects/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>المشاريع</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/projects/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -129,11 +127,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/research/index.html
+++ b/docs/ar/research/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>الأبحاث</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/research/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -80,7 +78,10 @@
   <div id="rGrid" class="r-grid">
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="palestine,archaeology,heritage" data-i="0">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="فلسطين,آثار,تراث"
+               data-i="0">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -90,17 +91,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Ramallah: Geography, History &amp; Heritage</h3>
+          <h3 class="r-title">رام الله: الجغرافيا، التاريخ، والتراث</h3>
           
-          <p class="r-desc">Survey of Ramallah’s geology and archaeological periods (Neolithic→Islamic/modern), with recommendations to use modern survey &amp; AI for protection/documentation, plus community–academic partnerships and cultural tourism.</p>
+          <p class="r-desc">مسح لجيولوجيا رام الله والفترات الأثرية (من العصر الحجري الحديث حتى الإسلامي/الحديث)، مع توصيات باستخدام المسح الحديث والذكاء الاصطناعي للحماية والتوثيق، إضافة إلى شراكات مجتمعية–أكاديمية وسياحة ثقافية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">palestine</span><span class="chip">archaeology</span><span class="chip">heritage</span>
+              <span class="chip">فلسطين</span><span class="chip">آثار</span><span class="chip">تراث</span>
             </div>
           
 
@@ -114,7 +117,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="ai-basics,workflow,learning" data-i="1">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="أساسيات-الذكاء-الاصطناعي,سير-العمل,تعلّم"
+               data-i="1">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -124,17 +130,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Beginner’s AI Roadmap</h3>
+          <h3 class="r-title">خارطة طريق للمبتدئين في الذكاء الاصطناعي</h3>
           
-          <p class="r-desc">Emphasizes core AI concepts over tool-chasing; roadmap covering LLMs, search, image/video/audio generation, automation/agents, and “vibe coding” to reclaim time and solve real pain points.</p>
+          <p class="r-desc">يركّز على المفاهيم الأساسية بدل مطاردة الأدوات؛ خارطة تغطي النماذج اللغوية، البحث، توليد الصور/الفيديو/الصوت، الأتمتة/الوكلاء، و«برمجة الفايب» لاستعادة الوقت وحل المشاكل الحقيقية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">ai-basics</span><span class="chip">workflow</span><span class="chip">learning</span>
+              <span class="chip">أساسيات-الذكاء-الاصطناعي</span><span class="chip">سير-العمل</span><span class="chip">تعلّم</span>
             </div>
           
 
@@ -148,7 +156,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="geopolitics,israel-palestine,ukraine" data-i="2">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="جيوسياسة,فلسطين-إسرائيل,أوكرانيا"
+               data-i="2">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -158,17 +169,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Endless Conflict: Russia, the West, and Israel</h3>
+          <h3 class="r-title">صراع بلا نهاية: روسيا، الغرب، و«إسرائيل»</h3>
           
-          <p class="r-desc">Chronology and key figures shaping global politics, focusing on the Israeli–Palestinian conflict and the war in Ukraine; touches on debates around NATO expansion, Mearsheimer’s analyses, and macro impacts.</p>
+          <p class="r-desc">خطٌّ زمني وشخصيات مؤثرة في السياسة العالمية مع تركيز على الصراع الفلسطيني–الإسرائيلي وحرب أوكرانيا؛ يتناول سجالات توسّع الناتو، تحليلات ميرشايمر، والآثار الكلية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">geopolitics</span><span class="chip">israel-palestine</span><span class="chip">ukraine</span>
+              <span class="chip">جيوسياسة</span><span class="chip">فلسطين-إسرائيل</span><span class="chip">أوكرانيا</span>
             </div>
           
 
@@ -182,7 +195,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="ai-futures,ethics,policy" data-i="3">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="مستقبلات-الذكاء-الاصطناعي,أخلاقيات,سياسات"
+               data-i="3">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -192,17 +208,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">AI Narratives: Reality &amp; 2030 Futures</h3>
+          <h3 class="r-title">سرديات الذكاء الاصطناعي: الواقع ومستقبل 2030</h3>
           
-          <p class="r-desc">Six narratives—progress/empowerment vs replacement/threat, digital colonialism, posthumanism, ethics, and bias/mirror—assessed with current evidence and practical notes for Arab policymakers.</p>
+          <p class="r-desc">ست سرديات: التقدّم/التمكين مقابل الاستبدال/التهديد، الاستعمار الرقمي، ما بعد الإنسانية، الأخلاقيات، والتحيّز/المرآة—تقييم بالأدلة الحالية وملاحظات عملية لصنّاع القرار العرب.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">ai-futures</span><span class="chip">ethics</span><span class="chip">policy</span>
+              <span class="chip">مستقبلات-الذكاء-الاصطناعي</span><span class="chip">أخلاقيات</span><span class="chip">سياسات</span>
             </div>
           
 
@@ -216,7 +234,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="canaan,rituals,archaeology" data-i="4">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="كنعان,طقوس,آثار"
+               data-i="4">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -226,17 +247,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Canaanite Rituals: Roots &amp; Expressions</h3>
+          <h3 class="r-title">طقوس كنعانية: الجذور والتعبيرات</h3>
           
-          <p class="r-desc">Late Bronze → early Iron Age rituals tied to agrarian calendars; temple/open-air practices; influences (Egypt, Phoenicia, Moab, Israel); scholarly debates (e.g., human sacrifice) and continuities in Palestinian memory.</p>
+          <p class="r-desc">طقوس من العصر البرونزي المتأخر إلى الحديدي المبكّر مرتبطة بالتقاويم الزراعية؛ ممارسات المعابد والفضاء المفتوح؛ التأثيرات (مصر، فينيقيا، مؤاب، إسرائيل)؛ سجالات أكاديمية (مثل مسألة القربان البشري) واستمراريات في الذاكرة الفلسطينية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">canaan</span><span class="chip">rituals</span><span class="chip">archaeology</span>
+              <span class="chip">كنعان</span><span class="chip">طقوس</span><span class="chip">آثار</span>
             </div>
           
 
@@ -250,7 +273,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="palestine,civilization,heritage" data-i="5">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="فلسطين,حضارة,تراث"
+               data-i="5">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -260,17 +286,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Palestine’s Legacy: Global Phenomena from the Holy Land</h3>
+          <h3 class="r-title">إرث فلسطين: ظواهر عالمية من الأرض المقدسة</h3>
           
-          <p class="r-desc">Highlights contributions such as the earliest alphabet, grain agriculture/terracing/irrigation, trade/diplomacy hubs (e.g., Gaza, Jaffa), hospitality culture, stone architecture, herbal medicine, and resistance literature.</p>
+          <p class="r-desc">إضاءات على مساهمات مثل أقدم الأبجديات، الزراعة الحبوبية/المدرّجات/الري، مراكز التجارة والدبلوماسية (غزّة، يافا)، ثقافة الضيافة، العمارة الحجرية، التداوي بالأعشاب، وأدب المقاومة.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">palestine</span><span class="chip">civilization</span><span class="chip">heritage</span>
+              <span class="chip">فلسطين</span><span class="chip">حضارة</span><span class="chip">تراث</span>
             </div>
           
 
@@ -284,7 +312,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="scenario,palestine,culture" data-i="6">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="سيناريو,فلسطين,ثقافة"
+               data-i="6">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -294,17 +325,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Palestine: Mirror of the World’s Conscience</h3>
+          <h3 class="r-title">فلسطين: مرآة ضمير العالم</h3>
           
-          <p class="r-desc">Scenario brief to 2030 on the disappearance of Palestine and global implications—cultural memory erosion, strained civic movements, leadership failures, and a wider loss of heritage and moral bearings.</p>
+          <p class="r-desc">ورقة سيناريو حتى 2030 عن اختفاء فلسطين وتداعياته العالمية—تآكل الذاكرة الثقافية، إنهاك الحركات المدنية، فشل القيادة، وخسارة أوسع للتراث والبوصلات الأخلاقية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">scenario</span><span class="chip">palestine</span><span class="chip">culture</span>
+              <span class="chip">سيناريو</span><span class="chip">فلسطين</span><span class="chip">ثقافة</span>
             </div>
           
 
@@ -318,7 +351,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="education,ai,skills" data-i="7">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="تعليم,ذكاء-اصطناعي,مهارات"
+               data-i="7">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -328,17 +364,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Learning &amp; AI: A Fundamental Shift</h3>
+          <h3 class="r-title">التعلّم والذكاء الاصطناعي: تحوّل جذري</h3>
           
-          <p class="r-desc">From rote learning to self-directed, flexible, higher-order skills; effects of AI on memory, focus, leadership; identity &amp; bias considerations; the rise of continuous learning and uniquely human skills.</p>
+          <p class="r-desc">انتقال من التلقين إلى التعلّم الذاتي المرن والمهارات العليا؛ أثر الذكاء الاصطناعي على الذاكرة والتركيز والقيادة؛ اعتبارات الهوية والتحيّز؛ صعود التعلّم المستمر والمهارات الإنسانية الفريدة.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">education</span><span class="chip">ai</span><span class="chip">skills</span>
+              <span class="chip">تعليم</span><span class="chip">ذكاء-اصطناعي</span><span class="chip">مهارات</span>
             </div>
           
 
@@ -352,7 +390,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="history,civilizations,comparative" data-i="8">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="تاريخ,حضارات,مقارنات"
+               data-i="8">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -362,17 +403,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Ancient Civilizations — Reappraising Durant</h3>
+          <h3 class="r-title">الحضارات القديمة — إعادة تقييم أطروحات ديورانت</h3>
           
-          <p class="r-desc">Re-evaluates Will &amp; Ariel Durant’s theses with post-1980 research; brings in Americas, Sub-Saharan Africa, East Asia; analyzes shared patterns (environment, trade, governance).</p>
+          <p class="r-desc">إعادة تقييم لأطروحات وِل وأريل ديورانت على ضوء أبحاث ما بعد الثمانينيات؛ إدخال الأمريكيتين وأفريقيا جنوب الصحراء وشرق آسيا؛ تحليل أنماط مشتركة (البيئة، التجارة، الحوكمة).</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">history</span><span class="chip">civilizations</span><span class="chip">comparative</span>
+              <span class="chip">تاريخ</span><span class="chip">حضارات</span><span class="chip">مقارنات</span>
             </div>
           
 
@@ -386,7 +429,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="rag,llms,tooling" data-i="9">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="RAG,نماذج-لغوية,أدوات"
+               data-i="9">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -396,17 +442,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">RAG (Retrieval-Augmented Generation): A Practical Guide</h3>
+          <h3 class="r-title">RAG (التوليد المعزّز بالاسترجاع): دليل عملي</h3>
           
-          <p class="r-desc">2025 tools landscape—NotebookLM, Midjourney v7, GPT/Claude, Suno, ElevenLabs, Veo, Gemini, Grok, DeepSeek—what RAG is, why it helps LLM accuracy, and where to apply it.</p>
+          <p class="r-desc">مشهد الأدوات في 2025—NotebookLM وMidjourney v7 وGPT/Claude وSuno وElevenLabs وVeo وGemini وGrok وDeepSeek—ما هو RAG ولماذا يحسّن دقّة النماذج اللغوية وأين يُطبّق.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">rag</span><span class="chip">llms</span><span class="chip">tooling</span>
+              <span class="chip">RAG</span><span class="chip">نماذج-لغوية</span><span class="chip">أدوات</span>
             </div>
           
 
@@ -420,7 +468,10 @@
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="history,methodology,debate" data-i="10">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="تاريخ,منهجية,نقاش"
+               data-i="10">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
@@ -430,17 +481,19 @@
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
         <div class="r-body">
-          <h3 class="r-title">Khazal Al-Majdi: Rethinking Narratives</h3>
+          <h3 class="r-title">خزعل الماجدي: إعادة التفكير في السرديات</h3>
           
-          <p class="r-desc">A critical discussion with historian Khazal Al-Majdi on archaeology-driven historiography, development of Judaism, debates around evidence, the decline of rational inquiry, and a call for scientific/philosophical renewal.</p>
+          <p class="r-desc">نقاش نقدي مع المؤرّخ خزعل الماجدي حول التأريخ المُسند بالآثار، تطوّر اليهودية، السجالات حول الدليل، تراجع inquiry العقلاني، ودعوة إلى نهضة علمية/فلسفية.</p>
 
           
+          
             <div class="r-tags">
-              <span class="chip">history</span><span class="chip">methodology</span><span class="chip">debate</span>
+              <span class="chip">تاريخ</span><span class="chip">منهجية</span><span class="chip">نقاش</span>
             </div>
           
 
@@ -481,11 +534,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/ar/training-consulting/index.html
+++ b/docs/ar/training-consulting/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>التدريب والاستشارات</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -41,11 +40,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/ar/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/training-consulting/">English</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/ar/">الرئيسية</a>
         <a href="/Tamer-Portfolio/ar/projects/">المشاريع</a>
@@ -59,7 +58,6 @@
         
         <a href="/Tamer-Portfolio/ar/about/">نبذة</a>
         <a href="/Tamer-Portfolio/ar/contact/">تواصل</a>
-        
       </nav>
     </div>
   </header>
@@ -317,11 +315,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/blog/category/Making-of/index.html
+++ b/docs/blog/category/Making-of/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/blog/category/Making-of/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -99,11 +97,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Blog</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/blog/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -108,11 +106,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/blog/tag/ai-film/index.html
+++ b/docs/blog/tag/ai-film/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/blog/tag/ai-film/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -100,11 +98,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/blog/tag/workflow/index.html
+++ b/docs/blog/tag/workflow/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/blog/tag/workflow/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -100,11 +98,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Contact</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/contact/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -173,11 +171,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/gallery/index.html
+++ b/docs/gallery/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Gallery</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/gallery/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -472,11 +470,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Home</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -236,11 +234,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/js/iab.js
+++ b/docs/js/iab.js
@@ -1,0 +1,5 @@
+(function () {
+  const ua = navigator.userAgent || "";
+  const isIAB = /FBAN|FBAV|FB_IAB|Instagram/i.test(ua);
+  if (isIAB) document.documentElement.classList.add("iab-fb");
+})();

--- a/docs/js/nav.js
+++ b/docs/js/nav.js
@@ -1,38 +1,130 @@
-(function () {
-  var toggle = document.querySelector('.nav-toggle');
-  var nav = document.getElementById('primary-nav');
-  if (!toggle || !nav) return;
+/* /src/js/nav.js
 
+ * Builds EN/AR nav, keeps GH Pages prefix, and toggles mobile menu.
+ */
+(function () {
+  // --- DOM ---
+  var toggle = document.querySelector('.nav-toggle');
+  var nav = document.getElementById('primary-nav') || document.querySelector('.nav-links');
+  var header = document.querySelector('header') || document.querySelector('.site-header') || document;
+
+  // --- Detect GH Pages prefix (/Tamer-Portfolio) ---
+  var PREFIX = (function () {
+    var m = location.pathname.match(/^\/[^/]+/);
+    return (m && m[0] && m[0].toLowerCase().includes('tamer-portfolio')) ? m[0] : '';
+  })();
+
+  var isAR = (location.pathname || '').startsWith(PREFIX + '/ar/');
+  var u = function (p, lang) { return PREFIX + (lang === 'ar' ? '/ar' : '') + p; };
+
+  // --- Menus ---
+  var MENU = {
+    en: [
+      { href: u('/', 'en'), label: 'Home' },
+      { href: u('/projects/', 'en'), label: 'Projects' },
+      { href: u('/media/', 'en'), label: 'Media' },
+      { href: u('/gallery/', 'en'), label: 'Gallery' },
+      { href: u('/music/', 'en'), label: 'Music' },
+      { href: u('/research/', 'en'), label: 'Research' },
+      { href: u('/training-consulting/', 'en'), label: 'Training & Consulting' },
+      { href: u('/blog/', 'en'), label: 'Blog' },
+      { href: u('/about/', 'en'), label: 'About' },
+      { href: u('/contact/', 'en'), label: 'Contact' }
+    ],
+    ar: [
+      { href: u('/', 'ar'), label: 'الرئيسية' },
+      { href: u('/projects/', 'ar'), label: 'المشاريع' },
+      { href: u('/media/', 'ar'), label: 'الوسائط' },
+      { href: u('/gallery/', 'ar'), label: 'المعرض' },
+      { href: u('/music/', 'ar'), label: 'الموسيقى' },
+      { href: u('/research/', 'ar'), label: 'الأبحاث' },
+      { href: u('/training-consulting/', 'ar'), label: 'التدريب والاستشارات' },
+      { href: u('/blog/', 'ar'), label: 'المدونة' },
+      { href: u('/about/', 'ar'), label: 'نبذة' },
+      { href: u('/contact/', 'ar'), label: 'تواصل' }
+    ]
+  };
+
+  function switchPath(to) {
+    var rest = (location.pathname || '').replace(PREFIX, '') || '/';
+    if (to === 'ar') {
+      if (!rest.startsWith('/ar/')) rest = '/ar' + (rest === '/' ? '/' : rest);
+    } else {
+      rest = rest.replace(/^\/ar(\/|$)/, '/');
+    }
+    return PREFIX + rest + location.search + location.hash;
+  }
+
+  // --- Render menu & language switch ---
+  function renderMenu(lang) {
+    if (!nav) return;
+    while (nav.firstChild) nav.removeChild(nav.firstChild);
+
+    MENU[lang].forEach(function (item) {
+      var a = document.createElement('a');
+      a.href = item.href;
+      a.textContent = item.label;
+      nav.appendChild(a);
+    });
+
+    // زر اللغة (أعلى)
+    var topSwitch = header.querySelector('.lang-switch-top');
+    if (!topSwitch) {
+      topSwitch = document.createElement('a');
+      topSwitch.className = 'lang-switch-top';
+      (header.querySelector('.nav-row') || header).appendChild(topSwitch);
+    }
+    if (lang === 'ar') { topSwitch.textContent = 'English'; topSwitch.href = switchPath('en'); }
+    else { topSwitch.textContent = 'العربية'; topSwitch.href = switchPath('ar'); }
+
+    // زر لغة داخل القائمة للموبايل (لو تحب وجوده)
+    var bottomSwitch = nav.querySelector('.lang-switch');
+    if (!bottomSwitch) {
+      bottomSwitch = document.createElement('a');
+      bottomSwitch.className = 'lang-switch';
+      nav.appendChild(bottomSwitch);
+    }
+    if (lang === 'ar') { bottomSwitch.textContent = 'English'; bottomSwitch.href = switchPath('en'); }
+    else { bottomSwitch.textContent = 'العربية'; bottomSwitch.href = switchPath('ar'); }
+  }
+
+  // --- نفس منطق الفتح/الإغلاق الأصلي تبعك ---
   function setOpen(open) {
+    if (!toggle || !nav) return;
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     nav.classList.toggle('open', open);
     document.body.classList.toggle('nav-open', open);
+    if (header && header.classList) {
+      header.classList.toggle('nav-open', open);
+    }
   }
 
-  // Ensure closed on load (prevents stuck overlay on some Android)
-  setOpen(false);
+  renderMenu(isAR ? 'ar' : 'en');
 
-  toggle.addEventListener('click', function () {
-    setOpen(!nav.classList.contains('open'));
-  });
+  if (toggle && nav) {
+    setOpen(false);
+    toggle.addEventListener('click', function () {
+      setOpen(!nav.classList.contains('open'));
+    });
 
-  nav.addEventListener('click', function (e) {
-    var a = e.target.closest('a');
-    if (!a) return;
-    var href = a.getAttribute('href') || '';
-    if (href.startsWith('#')) {
-      e.preventDefault();
-      try { document.querySelector(href).scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch(_) {}
-    }
-    setOpen(false); // close menu; allow navigation normally
-  });
+    nav.addEventListener('click', function (e) {
+      var a = e.target.closest('a');
+      if (!a) return;
+      var href = a.getAttribute('href') || '';
+      if (href.indexOf('#') === 0) {
+        e.preventDefault();
+        try {
+          var target = document.querySelector(href);
+          if (target && typeof target.scrollIntoView === 'function') {
+            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        } catch (_) {}
+      }
+      setOpen(false);
+    });
 
-  // Safety: close on back/forward cache restore or history traversal
-  window.addEventListener('pageshow', function(){ setOpen(false); });
-
-  // Escape closes
-  document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setOpen(false); });
-
-  // Resize to desktop closes
-  window.addEventListener('resize', function () { if (window.innerWidth > 900) setOpen(false); });
+    window.addEventListener('pageshow', function () { setOpen(false); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' || e.key === 'Esc') setOpen(false); });
+    window.addEventListener('resize', function () { if (window.innerWidth > 900) setOpen(false); });
+  }
 })();

--- a/docs/media/index.html
+++ b/docs/media/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Media &amp; Reels</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/media/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -82,14 +80,14 @@
   <div class="art-grid" id="mediaGrid">
     
       
-      <article class="art-card js-video" data-yt="dqGQJQ1jvHg" data-title="I Am the Land — Visual Poem" data-tags="poem,palestine,visual">
+      <article class="art-card js-video" data-yt="dqGQJQ1jvHg" data-title="I Am the Land — Visual Poem (Mahmoud Darwish-inspired)" data-tags="poem,palestine,visual">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/dqGQJQ1jvHg/hqdefault.jpg" alt="I Am the Land — Visual Poem" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/dqGQJQ1jvHg/hqdefault.jpg" alt="I Am the Land — Visual Poem (Mahmoud Darwish-inspired)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">I Am the Land — Visual Poem</h3>
-          <p class="art-desc">A visual poem inspired by Mahmoud Darwish — voice, memory-made imagery, and AI cinematics.</p>
+          <h3 class="art-title">I Am the Land — Visual Poem (Mahmoud Darwish-inspired)</h3>
+          <p class="art-desc">A visual poem voiced in the style of Mahmoud Darwish; memory-made imagery and AI cinematics weave Palestine’s voice into one intimate monologue.</p>
           
             <div class="tags">
               
@@ -106,22 +104,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="TcxHhyMLvfo" data-title="Generative Portraits — Motion Study" data-tags="ai-film,portrait,study">
+      <article class="art-card js-video" data-yt="TcxHhyMLvfo" data-title="Mona Lisa Rewired — AI Glitch Journey" data-tags="ai-film,glitch,mona-lisa">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/TcxHhyMLvfo/hqdefault.jpg" alt="Generative Portraits — Motion Study" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/TcxHhyMLvfo/hqdefault.jpg" alt="Mona Lisa Rewired — AI Glitch Journey" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Generative Portraits — Motion Study</h3>
-          <p class="art-desc">Short study in generative motion and portrait texture. Hand-crafted prompts + minimal cuts.</p>
+          <h3 class="art-title">Mona Lisa Rewired — AI Glitch Journey</h3>
+          <p class="art-desc">A 3:30 sensory stress-test—dozens of AI style passes over the Mona Lisa under a raw Suno glitch track. Headphones advised.</p>
           
             <div class="tags">
               
                 <span class="chip">ai-film</span>
               
-                <span class="chip">portrait</span>
+                <span class="chip">glitch</span>
               
-                <span class="chip">study</span>
+                <span class="chip">mona-lisa</span>
               
             </div>
           
@@ -130,22 +128,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="hjLWd6J86U8" data-title="Memory of Stones — Short Reel" data-tags="reel,palestine,texture">
+      <article class="art-card js-video" data-yt="hjLWd6J86U8" data-title="A Unified Palestinian Message (Veo 3)" data-tags="palestine,veo3,message">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/hjLWd6J86U8/hqdefault.jpg" alt="Memory of Stones — Short Reel" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/hjLWd6J86U8/hqdefault.jpg" alt="A Unified Palestinian Message (Veo 3)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Memory of Stones — Short Reel</h3>
-          <p class="art-desc">Reel exploring stone, dust, and archival textures as living memory.</p>
+          <h3 class="art-title">A Unified Palestinian Message (Veo 3)</h3>
+          <p class="art-desc">A collective cry from Gaza, the West Bank, Jerusalem, the ’48 lands, camps and diaspora—produced with Veo 3, voiced with real hope and resolve.</p>
           
             <div class="tags">
               
-                <span class="chip">reel</span>
-              
                 <span class="chip">palestine</span>
               
-                <span class="chip">texture</span>
+                <span class="chip">veo3</span>
+              
+                <span class="chip">message</span>
               
             </div>
           
@@ -154,22 +152,24 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="nBkYRVSdio4" data-title="City of Echoes — AI Music Cut" data-tags="music,ai-film,reel">
+      <article class="art-card js-video" data-yt="nBkYRVSdio4" data-title="DNA &amp; the Levant — Are Palestinians Canaanite Descendants? (Podcast)" data-tags="podcast,dna,canaanites,palestine">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/nBkYRVSdio4/hqdefault.jpg" alt="City of Echoes — AI Music Cut" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/nBkYRVSdio4/hqdefault.jpg" alt="DNA &amp; the Levant — Are Palestinians Canaanite Descendants? (Podcast)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">City of Echoes — AI Music Cut</h3>
-          <p class="art-desc">Music-driven visual cut; rhythms guide scenes through light and shadow.</p>
+          <h3 class="art-title">DNA &amp; the Levant — Are Palestinians Canaanite Descendants? (Podcast)</h3>
+          <p class="art-desc">A clear dive into 2017–2025 ancient-DNA studies linking modern Palestinians to ancient Canaanites; identity, continuity and myth-busting.</p>
           
             <div class="tags">
               
-                <span class="chip">music</span>
+                <span class="chip">podcast</span>
               
-                <span class="chip">ai-film</span>
+                <span class="chip">dna</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">canaanites</span>
+              
+                <span class="chip">palestine</span>
               
             </div>
           
@@ -178,22 +178,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="4_OvFXOjkWU" data-title="Eyes of Gaza — Microfilm" data-tags="palestine,microfilm,poem">
+      <article class="art-card js-video" data-yt="4_OvFXOjkWU" data-title="Do We Live in a Simulation? — 20 Theories (Podcast)" data-tags="podcast,philosophy,simulation">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/4_OvFXOjkWU/hqdefault.jpg" alt="Eyes of Gaza — Microfilm" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/4_OvFXOjkWU/hqdefault.jpg" alt="Do We Live in a Simulation? — 20 Theories (Podcast)" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Eyes of Gaza — Microfilm</h3>
-          <p class="art-desc">Microfilm sequence — glances, rubble, and resilience. Minimal text, strong imagery.</p>
+          <h3 class="art-title">Do We Live in a Simulation? — 20 Theories (Podcast)</h3>
+          <p class="art-desc">An AI-assisted NotebookLM episode exploring 20 frameworks of reality—from simulation to multiverses—with prompts and thought exercises.</p>
           
             <div class="tags">
               
-                <span class="chip">palestine</span>
+                <span class="chip">podcast</span>
               
-                <span class="chip">microfilm</span>
+                <span class="chip">philosophy</span>
               
-                <span class="chip">poem</span>
+                <span class="chip">simulation</span>
               
             </div>
           
@@ -202,20 +202,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="o5f5cjZw_j8" data-title="Echoes of the Land — Song" data-tags="music,palestine">
+      <article class="art-card js-video" data-yt="o5f5cjZw_j8" data-title="Echoes of the Land — Song" data-tags="music,palestine,civilizations">
         <div class="art-thumb">
           <img src="https://i.ytimg.com/vi/o5f5cjZw_j8/hqdefault.jpg" alt="Echoes of the Land — Song" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
           <h3 class="art-title">Echoes of the Land — Song</h3>
-          <p class="art-desc">A song from the heart of Palestine — traditional motifs blended with AI arrangement.</p>
+          <p class="art-desc">A musical journey through eras of Palestine—motifs, dress, and languages woven into one emotive chorus.</p>
           
             <div class="tags">
               
                 <span class="chip">music</span>
               
                 <span class="chip">palestine</span>
+              
+                <span class="chip">civilizations</span>
               
             </div>
           
@@ -224,22 +226,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="T55aC2muItM" data-title="Desert Birds — Visual Study" data-tags="study,minimal,reel">
+      <article class="art-card js-video" data-yt="T55aC2muItM" data-title="The Unbroken Palestinian — Rap" data-tags="rap,palestine,resilience">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/T55aC2muItM/hqdefault.jpg" alt="Desert Birds — Visual Study" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/T55aC2muItM/hqdefault.jpg" alt="The Unbroken Palestinian — Rap" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Desert Birds — Visual Study</h3>
-          <p class="art-desc">Minimal shots and grain — studying motion like birds over dunes.</p>
+          <h3 class="art-title">The Unbroken Palestinian — Rap</h3>
+          <p class="art-desc">A raw anthem of resilience—sharp lyrics and heavy beats voicing pain, struggle and unyielding hope.</p>
           
             <div class="tags">
               
-                <span class="chip">study</span>
+                <span class="chip">rap</span>
               
-                <span class="chip">minimal</span>
+                <span class="chip">palestine</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">resilience</span>
               
             </div>
           
@@ -248,22 +250,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="T64Vv0Opdfs" data-title="Olive Branch Dreams — Reel" data-tags="olive,reel,visual">
+      <article class="art-card js-video" data-yt="T64Vv0Opdfs" data-title="The Metaphorical Map of Tamer’s Life" data-tags="biography,metaphor,story">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/T64Vv0Opdfs/hqdefault.jpg" alt="Olive Branch Dreams — Reel" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/T64Vv0Opdfs/hqdefault.jpg" alt="The Metaphorical Map of Tamer’s Life" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Olive Branch Dreams — Reel</h3>
-          <p class="art-desc">Olive leaves, fabric patterns, and soft light — a reel about calm resistance.</p>
+          <h3 class="art-title">The Metaphorical Map of Tamer’s Life</h3>
+          <p class="art-desc">A symbolic biography: inner landscapes, creatures and motifs mapping ambition, creativity and continual transformation.</p>
           
             <div class="tags">
               
-                <span class="chip">olive</span>
+                <span class="chip">biography</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">metaphor</span>
               
-                <span class="chip">visual</span>
+                <span class="chip">story</span>
               
             </div>
           
@@ -272,20 +274,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="hrYES6lzX9E" data-title="Dawn Over the Hills — Ambient Cut" data-tags="ambient,reel">
+      <article class="art-card js-video" data-yt="hrYES6lzX9E" data-title="Echoes of History — Ibn Sina" data-tags="history,ibn-sina,philosophy">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/hrYES6lzX9E/hqdefault.jpg" alt="Dawn Over the Hills — Ambient Cut" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/hrYES6lzX9E/hqdefault.jpg" alt="Echoes of History — Ibn Sina" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Dawn Over the Hills — Ambient Cut</h3>
-          <p class="art-desc">Ambient visuals at first light — slow camera, long frames.</p>
+          <h3 class="art-title">Echoes of History — Ibn Sina</h3>
+          <p class="art-desc">A contemplative portrait of Avicenna—knowledge, medicine and philosophy in everyday scenes and timeless quotes.</p>
           
             <div class="tags">
               
-                <span class="chip">ambient</span>
+                <span class="chip">history</span>
               
-                <span class="chip">reel</span>
+                <span class="chip">ibn-sina</span>
+              
+                <span class="chip">philosophy</span>
               
             </div>
           
@@ -294,20 +298,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="ZvbIeKdasOc" data-title="Broken Frame — Experimental Edit" data-tags="experimental,ai-film">
+      <article class="art-card js-video" data-yt="ZvbIeKdasOc" data-title="Echoes of History — Mandela’s Dawn" data-tags="history,mandela,freedom">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/ZvbIeKdasOc/hqdefault.jpg" alt="Broken Frame — Experimental Edit" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/ZvbIeKdasOc/hqdefault.jpg" alt="Echoes of History — Mandela’s Dawn" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Broken Frame — Experimental Edit</h3>
-          <p class="art-desc">Experimental pacing and frame tearing — testing limits of AI motion.</p>
+          <h3 class="art-title">Echoes of History — Mandela’s Dawn</h3>
+          <p class="art-desc">A quiet moment around Mandela’s release—dawn of freedom and the road that followed.</p>
           
             <div class="tags">
               
-                <span class="chip">experimental</span>
+                <span class="chip">history</span>
               
-                <span class="chip">ai-film</span>
+                <span class="chip">mandela</span>
+              
+                <span class="chip">freedom</span>
               
             </div>
           
@@ -316,22 +322,22 @@
       </article>
     
       
-      <article class="art-card js-video" data-yt="L66kKVmgZRI" data-title="Sand &amp; Light — Minimal Poetics" data-tags="minimal,poem,visual">
+      <article class="art-card js-video" data-yt="L66kKVmgZRI" data-title="Roots of Resilience — A Journey Through Palestine" data-tags="palestine,heritage,orchestral">
         <div class="art-thumb">
-          <img src="https://i.ytimg.com/vi/L66kKVmgZRI/hqdefault.jpg" alt="Sand &amp; Light — Minimal Poetics" loading="lazy" width="480" height="270">
+          <img src="https://i.ytimg.com/vi/L66kKVmgZRI/hqdefault.jpg" alt="Roots of Resilience — A Journey Through Palestine" loading="lazy" width="480" height="270">
           <button class="watch-btn" type="button" aria-label="Play video">► Watch</button>
         </div>
         <div class="art-body">
-          <h3 class="art-title">Sand &amp; Light — Minimal Poetics</h3>
-          <p class="art-desc">Minimal visual poetics: sand, wind, and soft light in quiet loops.</p>
+          <h3 class="art-title">Roots of Resilience — A Journey Through Palestine</h3>
+          <p class="art-desc">An orchestral, image-rich tribute to Palestinian heritage—from olive groves to coastal waves and sacred streets.</p>
           
             <div class="tags">
               
-                <span class="chip">minimal</span>
+                <span class="chip">palestine</span>
               
-                <span class="chip">poem</span>
+                <span class="chip">heritage</span>
               
-                <span class="chip">visual</span>
+                <span class="chip">orchestral</span>
               
             </div>
           
@@ -364,11 +370,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/music/index.html
+++ b/docs/music/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Music</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/music/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -209,11 +207,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Projects</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/projects/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -131,11 +129,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Research</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
-  <meta name="description" content="Interactive research notebooks you can explore (NotebookLM).">
+  <meta name="description" content="Interactive notebooks you can explore (NotebookLM).">
   <meta property="og:title" content="Research">
-  <meta property="og:description" content="Interactive research notebooks you can explore (NotebookLM).">
+  <meta property="og:description" content="Interactive notebooks you can explore (NotebookLM).">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/research/">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/research/">
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/research/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -71,7 +69,7 @@
 <section class="container section-pad research-page">
   <header class="r-hero">
     <h1>Research</h1>
-    <p class="lead">Interactive notebooks and deep dives — open and explore them live.</p>
+    <p class="lead">Interactive notebooks and deep dives — open and explore directly.</p>
   </header>
 
   <div class="media-tools">
@@ -82,17 +80,20 @@
   <div id="rGrid" class="r-grid">
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="palestine,archaeology,heritage">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="palestine,archaeology,heritage"
+               data-i="0">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -102,39 +103,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">palestine</span>
-              
-                <span class="chip">archaeology</span>
-              
-                <span class="chip">heritage</span>
-              
+              <span class="chip">palestine</span><span class="chip">archaeology</span><span class="chip">heritage</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/ffb6d467-d0c1-4406-aab5-fcb8055db229" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/ffb6d467-d0c1-4406-aab5-fcb8055db229" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/ffb6d467-d0c1-4406-aab5-fcb8055db229">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="ai-basics,workflow,learning">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="ai-basics,workflow,learning"
+               data-i="1">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -144,39 +140,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">ai-basics</span>
-              
-                <span class="chip">workflow</span>
-              
-                <span class="chip">learning</span>
-              
+              <span class="chip">ai-basics</span><span class="chip">workflow</span><span class="chip">learning</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/af775138-9c58-47d5-ac47-f9ab34b48167" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/af775138-9c58-47d5-ac47-f9ab34b48167" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/af775138-9c58-47d5-ac47-f9ab34b48167">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="geopolitics,israel-palestine,ukraine">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="geopolitics,israel-palestine,ukraine"
+               data-i="2">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -186,39 +177,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">geopolitics</span>
-              
-                <span class="chip">israel-palestine</span>
-              
-                <span class="chip">ukraine</span>
-              
+              <span class="chip">geopolitics</span><span class="chip">israel-palestine</span><span class="chip">ukraine</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/623fa683-ec4a-4af9-a399-66c42670e695" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/623fa683-ec4a-4af9-a399-66c42670e695" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/623fa683-ec4a-4af9-a399-66c42670e695">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="ai-futures,ethics,policy">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="ai-futures,ethics,policy"
+               data-i="3">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -228,39 +214,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">ai-futures</span>
-              
-                <span class="chip">ethics</span>
-              
-                <span class="chip">policy</span>
-              
+              <span class="chip">ai-futures</span><span class="chip">ethics</span><span class="chip">policy</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/421e3dc7-3b05-461c-8e2f-01e2a985abf4" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/421e3dc7-3b05-461c-8e2f-01e2a985abf4" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/421e3dc7-3b05-461c-8e2f-01e2a985abf4">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="canaan,rituals,archaeology">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="canaan,rituals,archaeology"
+               data-i="4">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -270,39 +251,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">canaan</span>
-              
-                <span class="chip">rituals</span>
-              
-                <span class="chip">archaeology</span>
-              
+              <span class="chip">canaan</span><span class="chip">rituals</span><span class="chip">archaeology</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/b3ceba97-cea4-41ce-8d4d-3386eb816ba6" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/b3ceba97-cea4-41ce-8d4d-3386eb816ba6" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/b3ceba97-cea4-41ce-8d4d-3386eb816ba6">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="palestine,civilization,heritage">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="palestine,civilization,heritage"
+               data-i="5">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -312,39 +288,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">palestine</span>
-              
-                <span class="chip">civilization</span>
-              
-                <span class="chip">heritage</span>
-              
+              <span class="chip">palestine</span><span class="chip">civilization</span><span class="chip">heritage</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/9f2c9b5e-5d0d-4f80-8783-27e6d8fecffa" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/9f2c9b5e-5d0d-4f80-8783-27e6d8fecffa" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/9f2c9b5e-5d0d-4f80-8783-27e6d8fecffa">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="scenario,palestine,culture">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="scenario,palestine,culture"
+               data-i="6">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -354,39 +325,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">scenario</span>
-              
-                <span class="chip">palestine</span>
-              
-                <span class="chip">culture</span>
-              
+              <span class="chip">scenario</span><span class="chip">palestine</span><span class="chip">culture</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/ce6dff68-d847-49ed-9350-67ba34949c10" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/ce6dff68-d847-49ed-9350-67ba34949c10" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/ce6dff68-d847-49ed-9350-67ba34949c10">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="education,ai,skills">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="education,ai,skills"
+               data-i="7">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -396,39 +362,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">education</span>
-              
-                <span class="chip">ai</span>
-              
-                <span class="chip">skills</span>
-              
+              <span class="chip">education</span><span class="chip">ai</span><span class="chip">skills</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/f127e7e7-6638-4ee5-9687-f2ef13e7ed0f" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/f127e7e7-6638-4ee5-9687-f2ef13e7ed0f" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/f127e7e7-6638-4ee5-9687-f2ef13e7ed0f">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="history,civilizations,comparative">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="history,civilizations,comparative"
+               data-i="8">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -438,39 +399,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">history</span>
-              
-                <span class="chip">civilizations</span>
-              
-                <span class="chip">comparative</span>
-              
+              <span class="chip">history</span><span class="chip">civilizations</span><span class="chip">comparative</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/35375de7-596e-4773-b1e8-60bd37821432" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/35375de7-596e-4773-b1e8-60bd37821432" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/35375de7-596e-4773-b1e8-60bd37821432">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="rag,llms,tooling">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="rag,llms,tooling"
+               data-i="9">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -480,39 +436,34 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">rag</span>
-              
-                <span class="chip">llms</span>
-              
-                <span class="chip">tooling</span>
-              
+              <span class="chip">rag</span><span class="chip">llms</span><span class="chip">tooling</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/1d062dc1-d3fa-45db-af07-b349d32b7693" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/1d062dc1-d3fa-45db-af07-b349d32b7693" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/1d062dc1-d3fa-45db-af07-b349d32b7693">Copy link</button>
           </div>
         </div>
       </article>
     
       
-      <article class="r-card js-r" data-type="notebooklm" data-topics="history,methodology,debate">
+      <article class="r-card js-r"
+               data-type="notebooklm"
+               data-topics="history,methodology,debate"
+               data-i="10">
         <div class="r-thumb">
           
             <div class="r-ph" aria-hidden="true">
-              
-                <span class="r-ico">📒</span>
+              <span class="r-ico">📒</span>
               
             </div>
           
           <span class="r-badge r-badge--notebooklm">
             NotebookLM
+            
           </span>
         </div>
 
@@ -522,22 +473,14 @@
 
           
             <div class="r-tags">
-              
-                <span class="chip">history</span>
-              
-                <span class="chip">methodology</span>
-              
-                <span class="chip">debate</span>
-              
+              <span class="chip">history</span><span class="chip">methodology</span><span class="chip">debate</span>
             </div>
           
 
-          <div class="r-meta">
-            <span class="r-date">2025-08-23</span>
-          </div>
+          <div class="r-meta"><span class="r-date">2025-08-23</span></div>
 
           <div class="r-cta">
-            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/6d6de860-87df-4be8-a987-8142fa004f3d" target="_blank" rel="noopener">Open Notebook ↗</a>
+            <a class="btn btn-primary" href="https://notebooklm.google.com/notebook/6d6de860-87df-4be8-a987-8142fa004f3d" target="_blank" rel="noopener">Open notebook ↗</a>
             <button class="btn btn-ghost js-copy" data-copy="https://notebooklm.google.com/notebook/6d6de860-87df-4be8-a987-8142fa004f3d">Copy link</button>
           </div>
         </div>
@@ -571,11 +514,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -197,7 +197,7 @@ footer .social-icons a img {
 .music-nav a:hover { background: rgba(255,255,255,.06); }
 .note { color:#bdbdbd; margin-bottom:.5rem; }
 
-/* ===== Projects 2.0 (clean, modern, subpath‑safe) ===== */
+/* ===== Projects 2.0 (clean, modern, subpath-safe) ===== */
 :root {
   /* Fallback chain so we work with either token set already in the file */
   --accent-olive: var(--olive, var(--olive-green, #6a7f4e));
@@ -224,7 +224,7 @@ footer .social-icons a img {
   border-left: 6px solid var(--accent-olive);
 }
 
-/* Two‑column layout with responsive stack */
+/* Two-column layout with responsive stack */
 .project-split{
   display: grid;
   grid-template-columns: 1.2fr 1fr;
@@ -686,59 +686,40 @@ footer .social-icons a img {
 }
 
 /* === Fix contrast on Training & Consulting page === */
-
-/* خلي النص العام في الصفحة أبيض لأن الخلفية داكنة */
 .svc-page { color: #fff; }
-
-/* العناوين والسطر التعريفي في الهيرو أوضح */
 .svc-hero-body h1,
 .svc-hero-body .lead {
   color: #fff;
   text-shadow: 0 2px 10px rgba(0,0,0,.55), 0 1px 2px rgba(0,0,0,.45);
 }
-
-/* قوّي التعتيم تحت النص في الهيرو */
 .svc-hero-body {
   background: linear-gradient(180deg, rgba(0,0,0,0.15), rgba(0,0,0,.72));
 }
-
-/* الأقسام غير الموجودة داخل بطاقات بيضاء تبقى نصها فاتح */
 .svc-who,
 .svc-process,
 .svc-faq,
 .svc-cta { color: #f1f1f1; }
-
-/* البطاقات البيضاء: نضمن النص غامق ومقروء داخلها */
 .svc-card { color: #111; background:#fff; }
-.svc-card * { color: inherit; } /* يرثوا اللون الغامق داخل الكرت */
-
-/* عناوين الأقسام خارج البطاقات */
+.svc-card * { color: inherit; }
 .svc-page h2 { color: #fff; }
-
-/* تحسين صغير للأزرار فوق صورة الهيرو */
 .svc-cta .btn { box-shadow: 0 6px 18px rgba(0,0,0,.25); }
 
 /* === Fix CTA contrast (make text dark on light background) === */
 .svc-cta-body,
 .svc-cta-body * { color:#111 !important; }
-
-.svc-cta-body { 
-  /* نفس الخلفية الخفيفة لكن نص داكن */
+.svc-cta-body {
   background: radial-gradient(circle at center, rgba(255,255,255,.85), rgba(255,255,255,.60));
 }
-
 .svc-cta-body .lead { opacity:.85; }
-
-/* أزرار أوضح فوق الخلفية الفاتحة */
 .svc-cta .btn {
   background:#fff; color:#111;
   border:1px solid rgba(0,0,0,.12);
   box-shadow:0 6px 18px rgba(0,0,0,.12);
 }
-
 .svc-cta .btn-primary {
-  background:#6a7f4e; color:#fff; border-color:#6a7f4e;   /* زيتوني ممتلئ */
+  background:#6a7f4e; color:#fff; border-color:#6a7f4e;
 }
+
 /* ===== About Page ===== */
 .about-page{
   --olive:#6a7f4e;
@@ -837,11 +818,7 @@ toolbelt-note{ margin-top:.5rem; opacity:.9; }
 .card-section h2{margin-top:0}
 
 /* --- Phase 1b: Home image sizing & responsive cropping --- */
-
-/* اضبط عرض الكونتينر شوية لتخفيف ضخامـة العناصر */
 .container{max-width:1040px}
-
-/* HERO image: نسبة 16:9 وارتفاع أقصى */
 .hero-figure{max-width:900px;margin-inline:auto}
 .hero-figure img{
   width:100%;
@@ -854,8 +831,6 @@ toolbelt-note{ margin-top:.5rem; opacity:.9; }
 @media (max-width:640px){
   .hero-figure img{max-height:280px}
 }
-
-/* About image: نسبة 4:3 وارتفاع أقصى */
 .media-split-figure img{
   width:100%;
   height:auto;
@@ -867,8 +842,6 @@ toolbelt-note{ margin-top:.5rem; opacity:.9; }
 @media (max-width:640px){
   .media-split-figure img{max-height:260px}
 }
-
-/* Sound cards images: نسبة 16:9 وارتفاع أقصى */
 .card-figure img{
   width:100%;
   height:auto;
@@ -876,8 +849,6 @@ toolbelt-note{ margin-top:.5rem; opacity:.9; }
   max-height:360px;
   object-fit:cover;
 }
-
-/* Artistic Snapshots thumbs: نسبة 3:2 وارتفاع أقصى */
 .snapshots-grid .snap img{
   width:100%;
   height:auto;
@@ -886,14 +857,10 @@ toolbelt-note{ margin-top:.5rem; opacity:.9; }
   object-fit:cover;
   border-radius:12px;
 }
-
-/* مسافات أخف شوية داخل الكروت */
 .card-section{padding:20px}
 @media (min-width:900px){
   .card-section{padding:24px}
 }
-
-/* تحسين بسيط للمنيو على الشاشات الضيقة */
 @media (max-width:768px){
   .nav-links a{padding:8px 0}
 }
@@ -935,8 +902,6 @@ html[dir="rtl"] body{direction:rtl}
 html[dir="rtl"] .nav-row{flex-direction:row-reverse}
 html[dir="rtl"] .nav-links{justify-content:flex-start}
 .lang-switch{margin-inline-start:auto;font-weight:700;text-decoration:underline}
-.skip-link{position:absolute;left:-9999px;top:auto}
-.skip-link:focus{left:16px;top:12px;z-index:1001;background:#fff;color:#000;padding:.4rem .6rem;border-radius:6px}
 .site-header{position:sticky;top:0;z-index:1000}
 .nav-row{display:flex;align-items:center;gap:1rem}
 .nav-toggle{display:none;background:transparent;border:0;font-size:1.35rem}
@@ -953,7 +918,9 @@ html[dir="rtl"] .nav-row{flex-direction:row-reverse}
 html[dir="rtl"] .lang-switch{margin-inline-end:auto}
 .r-ph{display:flex;align-items:center;justify-content:center;min-height:160px;border-radius:12px;background:hsl(210 10% 92% / .8);position:relative;overflow:hidden}
 .r-ph .r-ico{font-size:40px;opacity:.9}
-.r-card[data-i]{--i: attr(data-i number, 1)}
+
+/* تعطيل attr() لأنه يسبب مشاكل لبعض أدوات التصغير */
+.r-card[data-i]{ --i: 1; }
 .r-card .r-ph{background:linear-gradient(160deg, hsl(calc(var(--i)*36) 65% 90%) 0%, hsl(calc(var(--i)*36) 60% 85%) 100%)}
 .r-badge{position:absolute;left:10px;bottom:10px;background:#222;color:#fff;font-size:.7rem;padding:.2rem .4rem;border-radius:6px;opacity:.9}
 html[dir="rtl"] .r-badge{left:auto;right:10px}
@@ -965,16 +932,16 @@ html[dir="rtl"] .r-badge{left:auto;right:10px}
   /* لوحة القائمة كطبقة كاملة قابلة للتمرير */
   .site-header .nav-links{
     position:fixed;
-    top:56px;              /* ارتفاع الترويسة التقريبي */
+    top:56px;
     left:0; right:0; bottom:0;
-    display:none;          /* ستتحول لـ flex عند الفتح */
+    display:none;
     flex-direction:column;
     align-items:flex-start;
     gap:.6rem;
     padding:1rem 1.25rem 1.25rem;
     background:#fff;
     z-index:1002;
-    overflow:auto;         /* المهم: تمكين التمرير */
+    overflow:auto;
     box-shadow:0 6px 18px rgba(0,0,0,.08);
     border-bottom:1px solid #e6e6e6;
   }
@@ -984,8 +951,8 @@ html[dir="rtl"] .r-badge{left:auto;right:10px}
 
   /* زر اللغة مثبت أسفل القائمة */
   .site-header .nav-links .lang-switch{
-    order:9999;           /* ضعه آخر عنصر بصرف النظر عن مكانه في الـ HTML */
-    margin-top:auto;      /* ادفعه لأسفل */
+    order:9999;
+    margin-top:auto;
     width:100%;
     text-align:center;
     display:block;
@@ -997,20 +964,19 @@ html[dir="rtl"] .r-badge{left:auto;right:10px}
     background:#f4f5f2;
   }
 
-  /* داكن */
-  @media (prefers-color-scheme:dark){
-    .site-header .nav-links{background:#111;color:#fff;border-color:#222;box-shadow:0 10px 24px rgba(0,0,0,.35)}
-    .site-header .nav-links a{color:#fff}
-    .site-header .nav-links .lang-switch{
-      background:#1b1b1b;
-      border-top:1px solid rgba(255,255,255,.12);
-      color:#fff;
-    }
-  }
-
-  /* قفل سكرول الصفحة عند فتح القائمة */
-  body.nav-open{overflow:hidden}
+  /* (أُزيل التعشيش هنا) */
 }
+/* بديل قانوني لكتلة الدارك داخل الموبايل */
+@media (max-width:900px) and (prefers-color-scheme: dark){
+  .site-header .nav-links{background:#111;color:#fff;border-color:#222;box-shadow:0 10px 24px rgba(0,0,0,.35)}
+  .site-header .nav-links a{color:#fff}
+  .site-header .nav-links .lang-switch{
+    background:#1b1b1b;
+    border-top:1px solid rgba(255,255,255,.12);
+    color:#fff;
+  }
+}
+
 :root{--header-h:56px}
 html,body{min-height:100%}
 body{background:#fff;color:#111}
@@ -1038,17 +1004,15 @@ body{background:#fff;color:#111}
   .nav-toggle{display:block}
   .nav-links{
     position:fixed; left:0; right:0;
-    top:var(--header-h); 
-    /* Fallback first: */
+    top:var(--header-h);
     max-height:calc(100vh - var(--header-h));
-    /* Modern viewport on Android/iOS: */
     height:calc(100dvh - var(--header-h));
     display:none; flex-direction:column; align-items:flex-start; gap:.6rem;
     padding:1rem 1.25rem 1.25rem;
     background:#fff; color:inherit; z-index:1002;
     overflow:auto; box-shadow:0 6px 18px rgba(0,0,0,.08);
     border-bottom:1px solid #e6e6e6;
-    transform:translateZ(0); /* avoid white/black flashes on some GPUs */
+    transform:translateZ(0);
     will-change:transform;
   }
   .nav-links.open{display:flex}
@@ -1061,3 +1025,65 @@ html[dir="rtl"] .lang-switch-top{margin-inline-end:auto;margin-inline-start:0}
 
 /* Ensure main has a solid background to avoid "black frame" while images/video load */
 main#main-content{background:inherit}
+
+/* (Optional safety net—doesn't fix the root cause but prevents surprises) */
+html, body { overflow-x: hidden; }
+
+/* (Optional but good hygiene) */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* ===== Facebook/Instagram In-App fixes (scoped) ===== */
+.iab-fb header,
+.iab-fb .nav-links { color-scheme: light; }
+
+/* زر الهامبرغر: ألوان واضحة وغير متأثرة بستيلات النظام */
+.iab-fb .nav-toggle,
+.iab-fb .menu-toggle{
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: #fff;
+  border: 0;
+  padding: .5rem .65rem;
+  line-height: 1;
+  border-radius: 12px;
+  font-size: 1.6rem; /* لو الأيقونة نص (☰) */
+}
+.iab-fb .nav-toggle:focus,
+.iab-fb .menu-toggle:focus { outline: 2px dashed #fff; outline-offset: 3px; }
+
+/* خلفية القائمة المتنقلة أوف-كانفاس */
+@media (max-width: 767px){
+  .iab-fb .nav-links,
+  .iab-fb nav .links,
+  .iab-fb .mobile-menu{
+    position: fixed;
+    inset: 0;
+    display: none;
+    flex-direction: column;
+    gap: 1rem;
+    background: #0e1116;   /* داكن صريح */
+    color: #ffffff;
+    padding: 5rem 1.25rem 2rem;
+    z-index: 1000;
+  }
+  .iab-fb header.nav-open .nav-links,
+  .iab-fb header.nav-open nav .links,
+  .iab-fb header.nav-open .mobile-menu{ display: flex; }
+
+  .iab-fb .nav-links a,
+  .iab-fb nav .links a,
+  .iab-fb .mobile-menu a{ color:#fff; font-size:1.125rem; }
+}
+
+/* تباين النصوص في الأقسام الداكنة داخل FB WebView فقط */
+.iab-fb main,
+.iab-fb main p,
+.iab-fb main li,
+.iab-fb .section-pad p,
+.iab-fb .section-pad li { color: #e6e9ee; }
+
+/* في حال كان أيقونة القائمة SVG بـ currentColor، ثبّت اللون على الهيدر */
+.iab-fb header svg { color:#fff; fill: currentColor; }
+/* تعطيل أي تأثير قد يتصرف بشكل سيئ في WebView */
+.iab-fb .has-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; }

--- a/docs/training-consulting/index.html
+++ b/docs/training-consulting/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>Training &amp; Consulting</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -17,11 +18,9 @@
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
 
   
   
-    
     
     
     
@@ -43,11 +42,11 @@
     <div class="container nav-row">
       <a class="logo" href="/Tamer-Portfolio/">TM</a>
 
-      
       <a class="lang-switch-top" href="/Tamer-Portfolio/ar/training-consulting/">العربية</a>
 
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu" aria-haspopup="true">☰</button>
 
+      <!-- قائمة موحّدة للغتين -->
       <nav id="primary-nav" class="nav-links" aria-label="Primary">
         <a href="/Tamer-Portfolio/">Home</a>
         <a href="/Tamer-Portfolio/projects/">Projects</a>
@@ -61,7 +60,6 @@
         
         <a href="/Tamer-Portfolio/about/">About</a>
         <a href="/Tamer-Portfolio/contact/">Contact</a>
-        
       </nav>
     </div>
   </header>
@@ -321,11 +319,12 @@
     </div>
   </footer>
 
-  <script defer src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/nav.js"></script>
+  <script src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/lightbox.js"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
-    // force navigation for the top language switch on some Android browsers
+    // تأكيد انتقال زر اللغة على بعض متصفحات أندرويد
     document.addEventListener('click',function(e){
       var x=e.target.closest('a.lang-switch-top'); if(!x) return;
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }

--- a/src/js/iab.js
+++ b/src/js/iab.js
@@ -1,0 +1,5 @@
+(function () {
+  const ua = navigator.userAgent || "";
+  const isIAB = /FBAN|FBAV|FB_IAB|Instagram/i.test(ua);
+  if (isIAB) document.documentElement.classList.add("iab-fb");
+})();

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -6,7 +6,7 @@
   // --- DOM ---
   var toggle = document.querySelector('.nav-toggle');
   var nav = document.getElementById('primary-nav') || document.querySelector('.nav-links');
-  var header = document.querySelector('.site-header') || document;
+  var header = document.querySelector('header') || document.querySelector('.site-header') || document;
 
   // --- Detect GH Pages prefix (/Tamer-Portfolio) ---
   var PREFIX = (function () {
@@ -94,6 +94,9 @@
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     nav.classList.toggle('open', open);
     document.body.classList.toggle('nav-open', open);
+    if (header && header.classList) {
+      header.classList.toggle('nav-open', open);
+    }
   }
 
   renderMenu(isAR ? 'ar' : 'en');

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>{{ title }}</title>
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -47,6 +48,8 @@
       </a>
     </div>
   </footer>
+  <script src="{{ '/src/js/nav.js' | url | versioned }}"></script>
+  <script src="{{ '/src/js/iab.js' | url | versioned }}"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
 </body>
 </html>

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
   <title>{{ title or site.title }}</title>
   <meta name="theme-color" content="#5a6b2c">
 
@@ -105,7 +106,8 @@
     </div>
   </footer>
 
-  <script defer src="{{ '/js/nav.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
+  <script src="{{ '/js/nav.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
+  <script src="{{ '/js/iab.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
   <script defer src="{{ '/js/lightbox.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1031,3 +1031,59 @@ html, body { overflow-x: hidden; }
 
 /* (Optional but good hygiene) */
 *, *::before, *::after { box-sizing: border-box; }
+
+/* ===== Facebook/Instagram In-App fixes (scoped) ===== */
+.iab-fb header,
+.iab-fb .nav-links { color-scheme: light; }
+
+/* زر الهامبرغر: ألوان واضحة وغير متأثرة بستيلات النظام */
+.iab-fb .nav-toggle,
+.iab-fb .menu-toggle{
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: #fff;
+  border: 0;
+  padding: .5rem .65rem;
+  line-height: 1;
+  border-radius: 12px;
+  font-size: 1.6rem; /* لو الأيقونة نص (☰) */
+}
+.iab-fb .nav-toggle:focus,
+.iab-fb .menu-toggle:focus { outline: 2px dashed #fff; outline-offset: 3px; }
+
+/* خلفية القائمة المتنقلة أوف-كانفاس */
+@media (max-width: 767px){
+  .iab-fb .nav-links,
+  .iab-fb nav .links,
+  .iab-fb .mobile-menu{
+    position: fixed;
+    inset: 0;
+    display: none;
+    flex-direction: column;
+    gap: 1rem;
+    background: #0e1116;   /* داكن صريح */
+    color: #ffffff;
+    padding: 5rem 1.25rem 2rem;
+    z-index: 1000;
+  }
+  .iab-fb header.nav-open .nav-links,
+  .iab-fb header.nav-open nav .links,
+  .iab-fb header.nav-open .mobile-menu{ display: flex; }
+
+  .iab-fb .nav-links a,
+  .iab-fb nav .links a,
+  .iab-fb .mobile-menu a{ color:#fff; font-size:1.125rem; }
+}
+
+/* تباين النصوص في الأقسام الداكنة داخل FB WebView فقط */
+.iab-fb main,
+.iab-fb main p,
+.iab-fb main li,
+.iab-fb .section-pad p,
+.iab-fb .section-pad li { color: #e6e9ee; }
+
+/* في حال كان أيقونة القائمة SVG بـ currentColor، ثبّت اللون على الهيدر */
+.iab-fb header svg { color:#fff; fill: currentColor; }
+/* تعطيل أي تأثير قد يتصرف بشكل سيئ في WebView */
+.iab-fb .has-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; }


### PR DESCRIPTION
## Summary
- detect Facebook/Instagram in-app browsers and add `iab-fb` class
- scope nav toggle, meta, and scripts to keep layout in light mode inside in-app browsers
- append CSS rules to override forced dark mode and ensure readable text

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `node node_modules/@11ty/eleventy/cmd.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5e9763c608322bbbf86002d734d25