### PR TITLE
Add Facebook in-app browser fixes and dark theme overrides

### DIFF
--- a/src/js/iab-nav-fix.js
+++ b/src/js/iab-nav-fix.js
@@ -1,0 +1,29 @@
+(function () {
+  if (!document.documentElement.classList.contains('iab-fb')) return;
+
+  const header = document.querySelector('header') || document.body;
+  const toggles = Array.from(document.querySelectorAll('.nav-toggle, .menu-toggle, [data-nav-toggle]'));
+  const menu = document.querySelector('.nav-links, nav .links, .mobile-menu') || document.querySelector('nav');
+  if (!header || !menu) return;
+
+  let pushed = false;
+
+  const isOpen = () => header.classList.contains('nav-open');
+  function openMenu() {
+    header.classList.add('nav-open');
+    document.body.style.overflow = 'hidden';
+    document.body.style.touchAction = 'none';
+    if (!pushed) { try { history.pushState({ iabNav: 1 }, ''); pushed = true; } catch(_){} }
+  }
+  function closeMenu() {
+    header.classList.remove('nav-open');
+    document.body.style.overflow = '';
+    document.body.style.touchAction = '';
+    if (pushed) { pushed = false; }
+  }
+
+  toggles.forEach(btn => btn.addEventListener('click', () => (isOpen() ? closeMenu() : openMenu()), { passive: true }));
+  menu.addEventListener('click', (e) => { if (e.target.closest('a')) closeMenu(); });
+  window.addEventListener('popstate', () => { if (isOpen()) closeMenu(); });
+  window.addEventListener('keydown', (e) => { if (e.key === 'Escape' && isOpen()) closeMenu(); });
+})();

--- a/src/js/iab.js
+++ b/src/js/iab.js
@@ -1,5 +1,7 @@
 (function () {
-  const ua = navigator.userAgent || "";
-  const isIAB = /FBAN|FBAV|FB_IAB|Instagram/i.test(ua);
-  if (isIAB) document.documentElement.classList.add("iab-fb");
+  try {
+    const ua = navigator.userAgent || "";
+    const isIAB = /FBAN|FBAV|FB_IAB|Instagram/i.test(ua);
+    if (isIAB) document.documentElement.classList.add("iab-fb");
+  } catch (_) {}
 })();

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -49,7 +49,8 @@
     </div>
   </footer>
   <script src="{{ '/src/js/nav.js' | url | versioned }}"></script>
-  <script src="{{ '/src/js/iab.js' | url | versioned }}"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
+  <script src="{{ '/src/js/iab.js' | url | versioned }}"></script>
+  <script src="{{ '/src/js/iab-nav-fix.js' | url | versioned }}"></script>
 </body>
 </html>

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -107,7 +107,6 @@
   </footer>
 
   <script src="{{ '/js/nav.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
-  <script src="{{ '/js/iab.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
   <script defer src="{{ '/js/lightbox.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script>
@@ -117,5 +116,7 @@
       var h=x.getAttribute('href'); if(h){ requestAnimationFrame(function(){ window.location.href=h; }); }
     });
   </script>
+  <script src="{{ '/js/iab.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
+  <script src="{{ '/js/iab-nav-fix.js' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}"></script>
 </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1087,3 +1087,34 @@ html, body { overflow-x: hidden; }
 .iab-fb header svg { color:#fff; fill: currentColor; }
 /* تعطيل أي تأثير قد يتصرف بشكل سيئ في WebView */
 .iab-fb .has-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; }
+/* Facebook In-App fixes (scoped) */
+.iab-fb html,
+.iab-fb body{
+  background:#0e1116 !important;
+  color:#e7ecf2 !important;
+  overflow-x:hidden;
+  overscroll-behavior-x:none;
+}
+@media (max-width: 767px){
+  .iab-fb .nav-links,
+  .iab-fb nav .links,
+  .iab-fb .mobile-menu{
+    background:#0e1116 !important;
+    color:#fff !important;
+  }
+  .iab-fb .nav-toggle,
+  .iab-fb .menu-toggle{ color:#fff !important; }
+}
+.iab-fb .section,
+.iab-fb .panel,
+.iab-fb .card,
+.iab-fb .surface,
+.iab-fb .container{
+  background-color:#141a22 !important;
+  color:#e7ecf2 !important;
+}
+.iab-fb main p,
+.iab-fb main li,
+.iab-fb .section p,
+.iab-fb .section li{ color:#e0e6ed !important; }
+.iab-fb .has-backdrop{ backdrop-filter:none; -webkit-backdrop-filter:none; }


### PR DESCRIPTION
## Summary
- Detect Facebook/Instagram in-app browsers and mark the page
- Handle menu navigation/back-button behaviour in Facebook's WebView
- Load the detection scripts in layouts and apply scoped dark style overrides

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -- --dry-run` *(fails: eleventy: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f48f9b4483228d9443a48f08d8e8