### PR TITLE
fix(media): enforce dark pill styles on desktop via .media-chipbar + CSS override

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -12,7 +12,7 @@
   <link rel="dns-prefetch" href="https://unavatar.io">
   <link rel="preconnect" href="https://notebooklm.google.com" crossorigin>
   <link rel="dns-prefetch" href="https://notebooklm.google.com">
-  <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
+  <link rel="stylesheet" href="{{ '/styles.css' | url }}?v=chipfix">
 </head>
 <body>
   <header>

--- a/src/media.njk
+++ b/src/media.njk
@@ -13,7 +13,7 @@ description: "AI-generated films, reels, and visual poems by Tamer Mansour."
 
   <div class="media-tools">
     <input id="mediaSearch" class="media-search" type="search" placeholder="Search videos…" aria-label="Search videos">
-    <div class="media-chips" id="mediaChips"></div>
+    <div class="media-chips media-chipbar" id="mediaChips"></div>
   </div>
 
   <div class="art-grid" id="mediaGrid">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1204,3 +1204,27 @@ html, body { overflow-x: hidden; }
 .media :is([class*="bg-white"],[style*="background: white"]) {
   background: var(--_chip-bg, var(--chip-bg)) !important;
 }
+
+/* === Media chipbar — enforce dark theme readability (desktop) === */
+:root{--chip-bg:#2b3a27;--chip-text:#eef6ec;--chip-border:#6f8c5c;--chip-bg-hover:#3a4c33;--chip-bg-active:#93b36f;--chip-text-active:#0e120c}
+
+/* Base pills styling inside the chipbar */
+.media-chipbar > *{display:inline-flex;align-items:center;gap:.35rem;padding:.45rem .85rem;border-radius:999px;border:1px solid var(--chip-border);background:var(--chip-bg);color:var(--chip-text);text-decoration:none;line-height:1;font-size:.92rem;cursor:pointer;transition:background .15s,color .15s,border-color .15s}
+
+/* Catch common classnames for existing pills without changing markup */
+.media-chipbar :is(.chip,.tag,.filter,.filter-btn,[class*="chip"],[class*="tag"],[class*="filter"],button,a,span){background:var(--chip-bg)!important;color:var(--chip-text)!important;border-color:var(--chip-border)!important}
+
+/* Hover + active */
+.media-chipbar :is(.chip,.tag,.filter,.filter-btn,button,a,span):hover{background:var(--chip-bg-hover)!important}
+.media-chipbar :is(.active,.is-active,[aria-pressed="true"],[data-active="true"]){background:var(--chip-bg-active)!important;color:var(--chip-text-active)!important;border-color:var(--chip-bg-active)!important}
+
+/* Fix any utility that forces white background */
+.media-chipbar :is([class*="bg-white"],[style*="background: white"]){background:var(--chip-bg)!important;color:var(--chip-text)!important}
+
+/* Icons inside pills inherit currentColor */
+.media-chipbar svg{width:1rem;height:1rem;color:currentColor;fill:currentColor}
+
+/* Scope a desktop-only reinforcement so mobile remains as-is if already good */
+@media (min-width:768px){
+  .media-chipbar > *{box-shadow:none}
+}


### PR DESCRIPTION
## Summary
- scope filter chips in media page inside `.media-chipbar` container
- append dark-theme chip styling overrides
- add cache-busting query param to base layout stylesheet link

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ✅ `node node_modules/@11ty/eleventy/cmd.js`


------
https://chatgpt.com/codex/tasks/task_e_68be7ba950c08322acb202258ca67c4a