### PR TITLE
Add sitemap and robots directives for SEO

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://tamermansour-ai.github.io/Tamer-Portfolio/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/research/ai-ethics-middle-east/</loc>
+      <lastmod>2024-06-15T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/Media/ai-youth-session/</loc>
+      <lastmod>2025-01-01T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/research/genetic-continuity/</loc>
+      <lastmod>2025-06-01T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/echoes-of-the-land/</loc>
+      <lastmod>2025-07-15T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/mona-lisa-glitch-mode/</loc>
+      <lastmod>2025-07-20T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/projects/atyaf-al-ard/</loc>
+      <lastmod>2025-07-25T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ana-al-ard/</loc>
+      <lastmod>2025-07-26T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/blog/behind-the-ai-lens/</loc>
+      <lastmod>2025-08-02T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/blog/creating-echoes-of-the-land/</loc>
+      <lastmod>2025-08-03T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/مثال-مقال/</loc>
+      <lastmod>2025-08-23T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/example-post/</loc>
+      <lastmod>2025-08-23T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/arab-storytelling-dahih/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/colonial-rulebook-6-stages/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/not-just-football-drama/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/arab-storytelling-dahih/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/colonial-rulebook-6-stages/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/not-just-football-drama/</loc>
+      <lastmod>2025-09-07T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/blog/2025-09-08-sample-ar/</loc>
+      <lastmod>2025-09-08T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/content/blog/2025-09-08-sample-en/</loc>
+      <lastmod>2025-09-08T00:00:00.000Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/about/</loc>
+      <lastmod>2025-12-15T20:09:02.747Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/category/يوميات-صناعة/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/سير-العمل/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/category/Making-of/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/contact/</loc>
+      <lastmod>2025-12-15T20:09:02.751Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/gallery/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/media/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/music/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/projects/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/research/</loc>
+      <lastmod>2025-12-15T20:09:03.099Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/ai-film/</loc>
+      <lastmod>2025-12-15T20:09:03.103Z</lastmod>
+    </url>
+    
+  
+    
+    <url>
+      <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/training-consulting/</loc>
+      <lastmod>2025-12-15T20:09:03.103Z</lastmod>
+    </url>
+    
+  
+    
+  
+    
+  
+</urlset>

--- a/src/robots.txt.njk
+++ b/src/robots.txt.njk
@@ -1,0 +1,6 @@
+---
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+Sitemap: https://tamermansour-ai.github.io/Tamer-Portfolio/sitemap.xml

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -1,0 +1,14 @@
+---
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+    {% if page.url and page.outputPath and page.outputPath.endsWith('.html') %}
+    <url>
+      <loc>{{ site.url }}{{ page.url }}</loc>
+      {% if page.date %}<lastmod>{{ page.date | dateToISO }}</lastmod>{% endif %}
+    </url>
+    {% endif %}
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
## Summary
- add Eleventy templates to generate sitemap.xml and robots.txt with absolute URLs
- include generated sitemap and robots files in the built docs output

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69406aaf71e483228a33eb768c0854b3)