### PR TITLE
Add hreflang alternates and structured data for bilingual pages

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 {# detect language (default en) and set RTL for Arabic #}
-{% set __lang = lang or page.lang or 'en' %}
+{% set __pageUrl = page.url or '/' %}
+{% set __isArabic = (__pageUrl | slice(0, 4)) == '/ar/' %}
+{% set __lang = lang or page.lang %}
+{% if not __lang %}
+  {% if __isArabic %}
+    {% set __lang = 'ar' %}
+  {% else %}
+    {% set __lang = 'en' %}
+  {% endif %}
+{% endif %}
 <html lang="{{ __lang }}" {% if __lang == 'ar' %}dir="rtl"{% endif %}>
 <head>
   <meta charset="UTF-8">
@@ -11,15 +20,60 @@
   {# basic SEO #}
   {% if description %}<meta name="description" content="{{ description }}">{% endif %}
   {% set __base = site.url or 'https://tamermansour-ai.github.io/Tamer-Portfolio' %}
+  {% set __canonical = __pageUrl | absoluteUrl(__base) %}
+  {% if __isArabic %}
+    {% set __enPath = __pageUrl | replace('/ar/', '/') %}
+    {% set __arPath = __pageUrl %}
+  {% else %}
+    {% set __enPath = __pageUrl %}
+    {% if __pageUrl == '/' %}
+      {% set __arPath = '/ar/' %}
+    {% else %}
+      {% set __arPath = '/ar' + __pageUrl %}
+    {% endif %}
+  {% endif %}
   {% set __og_image = site.url + '/assets/img/og-cover.svg' %}
-  <link rel="canonical" href="{{ page.url | absoluteUrl(__base) }}">
+  <link rel="canonical" href="{{ __canonical }}">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ page.url | absoluteUrl(__base) }}">
+  <meta property="og:url" content="{{ __canonical }}">
   <meta property="og:image" content="{{ __og_image }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ __og_image }}">
   {% if description %}<meta property="og:description" content="{{ description }}">{% endif %}
+
+  <link rel="alternate" hreflang="en" href="{{ __enPath | absoluteUrl(__base) }}">
+  <link rel="alternate" hreflang="ar" href="{{ __arPath | absoluteUrl(__base) }}">
+  <link rel="alternate" hreflang="x-default" href="{{ '/' | absoluteUrl(__base) }}">
+
+  {% set __socialLinks = [
+    'https://www.pinterest.com/TamerCreates/',
+    'https://www.tiktok.com/@ai_visionary_tm',
+    'https://www.youtube.com/@TamerAI-e5i'
+  ] %}
+  <script type="application/ld+json">
+    {{ {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": site.title or site.name or 'Tamer Mansour',
+      "url": __base,
+      "inLanguage": __lang,
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": __base + '/search?q={search_term_string}',
+        "query-input": "required name=search_term_string"
+      }
+    } | dump | safe }}
+  </script>
+  <script type="application/ld+json">
+    {{ {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": site.title or site.name or 'Tamer Mansour',
+      "url": __base,
+      "sameAs": __socialLinks
+    } | dump | safe }}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,5 +1,15 @@
 <!doctype html>
-<html lang="{{ lang or 'en' }}" {% if lang == 'ar' %}dir="rtl"{% endif %}>
+{% set __pageUrl = page.url or '/' %}
+{% set __isArabic = (__pageUrl | slice(0, 4)) == '/ar/' %}
+{% set __lang = lang or page.lang %}
+{% if not __lang %}
+  {% if __isArabic %}
+    {% set __lang = 'ar' %}
+  {% else %}
+    {% set __lang = 'en' %}
+  {% endif %}
+{% endif %}
+<html lang="{{ __lang }}" {% if __lang == 'ar' %}dir="rtl"{% endif %}>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,16 +17,64 @@
   <title>{{ title or site.title }}</title>
   <meta name="theme-color" content="#5a6b2c">
 
+  {% set __base = site.url or 'https://tamermansour-ai.github.io/Tamer-Portfolio' %}
+  {% set __canonical = __pageUrl | absoluteUrl(__base) %}
+  {% if __isArabic %}
+    {% set __enPath = __pageUrl | replace('/ar/', '/') %}
+    {% set __arPath = __pageUrl %}
+  {% else %}
+    {% set __enPath = __pageUrl %}
+    {% if __pageUrl == '/' %}
+      {% set __arPath = '/ar/' %}
+    {% else %}
+      {% set __arPath = '/ar' + __pageUrl %}
+    {% endif %}
+  {% endif %}
+  {% set __og_image = (site.url or __base) + '/assets/img/og-cover.svg' %}
+
   {% set desc = description or site.defaultDescription %}
   <meta name="description" content="{{ desc }}">
   <meta property="og:title" content="{{ title or site.title }}">
   <meta property="og:description" content="{{ desc }}">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-  <meta property="og:image" content="{{ site.url }}/assets/img/og-cover.svg">
+  <meta property="og:url" content="{{ __canonical }}">
+  <meta property="og:image" content="{{ __og_image }}">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="{{ site.url }}/assets/img/og-cover.svg">
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  <meta name="twitter:image" content="{{ __og_image }}">
+  <link rel="canonical" href="{{ __canonical }}">
+
+  <link rel="alternate" hreflang="en" href="{{ __enPath | absoluteUrl(__base) }}">
+  <link rel="alternate" hreflang="ar" href="{{ __arPath | absoluteUrl(__base) }}">
+  <link rel="alternate" hreflang="x-default" href="{{ '/' | absoluteUrl(__base) }}">
+
+  {% set __socialLinks = [
+    'https://www.pinterest.com/TamerCreates/',
+    'https://www.tiktok.com/@ai_visionary_tm',
+    'https://www.youtube.com/@TamerAI-e5i'
+  ] %}
+  <script type="application/ld+json">
+    {{ {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": site.title or site.name or 'Tamer Mansour — Portfolio',
+      "url": __base,
+      "inLanguage": __lang,
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": __base + '/search?q={search_term_string}',
+        "query-input": "required name=search_term_string"
+      }
+    } | dump | safe }}
+  </script>
+  <script type="application/ld+json">
+    {{ {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": site.title or site.name or 'Tamer Mansour',
+      "url": __base,
+      "sameAs": __socialLinks
+    } | dump | safe }}
+  </script>
 
   <link rel="stylesheet" href="{{ '/styles.css' | url }}{% if site.assetVersion %}?v={{ site.assetVersion }}{% endif %}">
 </head>


### PR DESCRIPTION
## Summary
- detect page language from URL to set the `<html lang>` and RTL flag correctly
- add canonical-aware hreflang alternates for English and Arabic versions across layouts
- embed WebSite and Person JSON-LD metadata using existing site and social details

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407ce566c083229e564e2c56d80276)