### PR TITLE
Fix SEO titles and stabilize footer year

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>About</title>
+  <title>About — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="Tamer Mansour — Palestinian creative technologist building AI-native stories &amp; systems.">
-  <meta property="og:title" content="About">
+  <meta property="og:title" content="About — Tamer Mansour">
   <meta property="og:description" content="Tamer Mansour — Palestinian creative technologist building AI-native stories &amp; systems.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/about/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="About — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/about/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/about/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -252,7 +287,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/about/index.html
+++ b/docs/ar/about/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>نبذة</title>
+  <title>نبذة — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="تامر منصور — مُبتكر فلسطيني في التكنولوجيا الإبداعية يبني حكايات وأنظمة أصلية بالذكاء الاصطناعي.">
-  <meta property="og:title" content="نبذة">
+  <meta property="og:title" content="نبذة — Tamer Mansour">
   <meta property="og:description" content="تامر منصور — مُبتكر فلسطيني في التكنولوجيا الإبداعية يبني حكايات وأنظمة أصلية بالذكاء الاصطناعي.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="نبذة — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/about/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -249,7 +280,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/blog/category/يوميات-صناعة/index.html
+++ b/docs/ar/blog/category/يوميات-صناعة/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/category/يوميات-صناعة/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/category/يوميات-صناعة/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/blog/category/يوميات-صناعة/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -109,7 +144,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/blog/index.html
+++ b/docs/ar/blog/index.html
@@ -1,25 +1,52 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>المدوّنة</title>
+  <title>المدوّنة — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/">
-  <meta property="og:title" content="المدوّنة">
+  <meta property="og:title" content="المدوّنة — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="المدوّنة — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/blog/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -125,7 +152,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -144,10 +171,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/ar/blog/tag/سير-العمل/index.html
+++ b/docs/ar/blog/tag/سير-العمل/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/سير-العمل/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/سير-العمل/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/blog/tag/سير-العمل/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -110,7 +145,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/blog/tag/فيديو-ذكاء-اصطناعي/index.html
+++ b/docs/ar/blog/tag/فيديو-ذكاء-اصطناعي/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/فيديو-ذكاء-اصطناعي/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/فيديو-ذكاء-اصطناعي/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/blog/tag/فيديو-ذكاء-اصطناعي/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -110,7 +145,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/contact/index.html
+++ b/docs/ar/contact/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>تواصل</title>
+  <title>تواصل — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="تواصل عبر البريد أو واتساب أو الشبكات الاجتماعية.">
-  <meta property="og:title" content="تواصل">
+  <meta property="og:title" content="تواصل — Tamer Mansour">
   <meta property="og:description" content="تواصل عبر البريد أو واتساب أو الشبكات الاجتماعية.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="تواصل — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/contact/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -173,7 +204,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/gallery/index.html
+++ b/docs/ar/gallery/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>المعرض</title>
+  <title>المعرض — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="مختارات من المرئيات التوليدية والريلز (مصادر خارجية).">
-  <meta property="og:title" content="المعرض">
+  <meta property="og:title" content="المعرض — Tamer Mansour">
   <meta property="og:description" content="مختارات من المرئيات التوليدية والريلز (مصادر خارجية).">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="المعرض — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/gallery/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -480,7 +511,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/index.html
+++ b/docs/ar/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>الرئيسية</title>
+  <title>الرئيسية — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="موقع تعريفي — هوية وذكريات وخيال مدعوم بالذكاء الاصطناعي.">
-  <meta property="og:title" content="الرئيسية">
+  <meta property="og:title" content="الرئيسية — Tamer Mansour">
   <meta property="og:description" content="موقع تعريفي — هوية وذكريات وخيال مدعوم بالذكاء الاصطناعي.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="الرئيسية — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -232,7 +263,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/media/index.html
+++ b/docs/ar/media/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>الوسائط والريلز</title>
+  <title>الوسائط والريلز — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="أفلام وتراكيب و«قصائد بصرية» مُولّدة بالذكاء الاصطناعي من تامر منصور.">
-  <meta property="og:title" content="الوسائط والريلز">
+  <meta property="og:title" content="الوسائط والريلز — Tamer Mansour">
   <meta property="og:description" content="أفلام وتراكيب و«قصائد بصرية» مُولّدة بالذكاء الاصطناعي من تامر منصور.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="الوسائط والريلز — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/media/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -379,7 +410,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/music/index.html
+++ b/docs/ar/music/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>الموسيقى</title>
+  <title>الموسيقى — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="مؤلفات ومشاهد صوتية مُولّدة بالذكاء الاصطناعي — مُنظمة حسب الحالة والمزاج.">
-  <meta property="og:title" content="الموسيقى">
+  <meta property="og:title" content="الموسيقى — Tamer Mansour">
   <meta property="og:description" content="مؤلفات ومشاهد صوتية مُولّدة بالذكاء الاصطناعي — مُنظمة حسب الحالة والمزاج.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="الموسيقى — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/music/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -207,7 +238,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/projects/index.html
+++ b/docs/ar/projects/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>المشاريع</title>
+  <title>المشاريع — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="مشاريع مختارة عبر الذكاء الاصطناعي والوسائط والبحث.">
-  <meta property="og:title" content="المشاريع">
+  <meta property="og:title" content="المشاريع — Tamer Mansour">
   <meta property="og:description" content="مشاريع مختارة عبر الذكاء الاصطناعي والوسائط والبحث.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="المشاريع — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/projects/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -139,7 +170,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/research/index.html
+++ b/docs/ar/research/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>الأبحاث</title>
+  <title>الأبحاث — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="دفاتر بحث تفاعلية يمكنك استكشافها (NotebookLM).">
-  <meta property="og:title" content="الأبحاث">
+  <meta property="og:title" content="الأبحاث — Tamer Mansour">
   <meta property="og:description" content="دفاتر بحث تفاعلية يمكنك استكشافها (NotebookLM).">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="الأبحاث — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/research/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -546,7 +577,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/ar/training-consulting/index.html
+++ b/docs/ar/training-consulting/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>التدريب والاستشارات</title>
+  <title>التدريب والاستشارات — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="تدريب ذكاء اصطناعي واستشارات إبداعية للفرق والمبدعين.">
-  <meta property="og:title" content="التدريب والاستشارات">
+  <meta property="og:title" content="التدريب والاستشارات — Tamer Mansour">
   <meta property="og:description" content="تدريب ذكاء اصطناعي واستشارات إبداعية للفرق والمبدعين.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="التدريب والاستشارات — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/ar/training-consulting/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"ar","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -327,7 +358,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/blog/category/Making-of/index.html
+++ b/docs/blog/category/Making-of/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/category/Making-of/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/category/Making-of/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/category/Making-of/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -109,7 +144,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,25 +1,52 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Blog</title>
+  <title>Blog — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/">
-  <meta property="og:title" content="Blog">
+  <meta property="og:title" content="Blog — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Blog — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -125,7 +152,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -144,10 +171,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/blog/tag/ai-film/index.html
+++ b/docs/blog/tag/ai-film/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/ai-film/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/ai-film/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/ai-film/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -110,7 +145,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/blog/tag/workflow/index.html
+++ b/docs/blog/tag/workflow/index.html
@@ -1,4 +1,16 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
@@ -6,6 +18,16 @@
   <meta name="color-scheme" content="light dark">
   <title>Tamer Mansour — Portfolio</title>
   <meta name="theme-color" content="#5a6b2c">
+
+  
+  
+  
+    
+    
+      
+    
+  
+  
 
   
   <meta name="description" content="">
@@ -16,7 +38,20 @@
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Tamer Mansour — Portfolio">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/workflow/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/workflow/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/workflow/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -110,7 +145,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Contact</title>
+  <title>Contact — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="Reach out via email, WhatsApp, or social channels.">
-  <meta property="og:title" content="Contact">
+  <meta property="og:title" content="Contact — Tamer Mansour">
   <meta property="og:description" content="Reach out via email, WhatsApp, or social channels.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/contact/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Contact — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/contact/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/contact/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -183,7 +218,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/content/media/ana-al-ard/index.html
+++ b/docs/content/media/ana-al-ard/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>أنا الأرض: قصيدة مصوّرة على لسان فلسطين</title>
+  <title>أنا الأرض: قصيدة مصوّرة على لسان فلسطين — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ana-al-ard/">
-  <meta property="og:title" content="أنا الأرض: قصيدة مصوّرة على لسان فلسطين">
+  <meta property="og:title" content="أنا الأرض: قصيدة مصوّرة على لسان فلسطين — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ana-al-ard/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="أنا الأرض: قصيدة مصوّرة على لسان فلسطين — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ana-al-ard/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/ana-al-ard/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -88,7 +119,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -107,10 +138,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/ar/arab-storytelling-dahih/index.html
+++ b/docs/content/media/ar/arab-storytelling-dahih/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>وثيقة إحاطة: فن الحكاية العربية — درس من الدحيح</title>
+  <title>وثيقة إحاطة: فن الحكاية العربية — درس من الدحيح — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/arab-storytelling-dahih/">
-  <meta property="og:title" content="وثيقة إحاطة: فن الحكاية العربية — درس من الدحيح">
+  <meta property="og:title" content="وثيقة إحاطة: فن الحكاية العربية — درس من الدحيح — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/arab-storytelling-dahih/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="وثيقة إحاطة: فن الحكاية العربية — درس من الدحيح — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/arab-storytelling-dahih/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/ar/arab-storytelling-dahih/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -102,7 +133,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -121,10 +152,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/ar/colonial-rulebook-6-stages/index.html
+++ b/docs/content/media/ar/colonial-rulebook-6-stages/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>دليل قواعد الاستعمار: 6 مراحل لغزو العالم… وما زال يلعب اليوم!</title>
+  <title>دليل قواعد الاستعمار: 6 مراحل لغزو العالم… وما زال يلعب اليوم! — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/colonial-rulebook-6-stages/">
-  <meta property="og:title" content="دليل قواعد الاستعمار: 6 مراحل لغزو العالم… وما زال يلعب اليوم!">
+  <meta property="og:title" content="دليل قواعد الاستعمار: 6 مراحل لغزو العالم… وما زال يلعب اليوم! — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/colonial-rulebook-6-stages/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="دليل قواعد الاستعمار: 6 مراحل لغزو العالم… وما زال يلعب اليوم! — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/colonial-rulebook-6-stages/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/ar/colonial-rulebook-6-stages/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -105,7 +136,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -124,10 +155,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/ar/not-just-football-drama/index.html
+++ b/docs/content/media/ar/not-just-football-drama/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>مش عن الكورة بس ⚽🔥 — السر الحقيقي وراء هوس العالم بالرياضة</title>
+  <title>مش عن الكورة بس ⚽🔥 — السر الحقيقي وراء هوس العالم بالرياضة — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/not-just-football-drama/">
-  <meta property="og:title" content="مش عن الكورة بس ⚽🔥 — السر الحقيقي وراء هوس العالم بالرياضة">
+  <meta property="og:title" content="مش عن الكورة بس ⚽🔥 — السر الحقيقي وراء هوس العالم بالرياضة — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/not-just-football-drama/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="مش عن الكورة بس ⚽🔥 — السر الحقيقي وراء هوس العالم بالرياضة — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/ar/not-just-football-drama/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/ar/not-just-football-drama/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -102,7 +133,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -121,10 +152,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/echoes-of-the-land/index.html
+++ b/docs/content/media/echoes-of-the-land/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Echoes of the Land – A Song from the Heart of Palestine</title>
+  <title>Echoes of the Land – A Song from the Heart of Palestine — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/echoes-of-the-land/">
-  <meta property="og:title" content="Echoes of the Land – A Song from the Heart of Palestine">
+  <meta property="og:title" content="Echoes of the Land – A Song from the Heart of Palestine — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/echoes-of-the-land/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Echoes of the Land – A Song from the Heart of Palestine — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/echoes-of-the-land/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/echoes-of-the-land/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -88,7 +119,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -107,10 +138,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/en/arab-storytelling-dahih/index.html
+++ b/docs/content/media/en/arab-storytelling-dahih/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Arab Storytelling Method — Lessons from Al Da7ee7</title>
+  <title>Arab Storytelling Method — Lessons from Al Da7ee7 — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/arab-storytelling-dahih/">
-  <meta property="og:title" content="Arab Storytelling Method — Lessons from Al Da7ee7">
+  <meta property="og:title" content="Arab Storytelling Method — Lessons from Al Da7ee7 — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/arab-storytelling-dahih/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Arab Storytelling Method — Lessons from Al Da7ee7 — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/arab-storytelling-dahih/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/en/arab-storytelling-dahih/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -102,7 +133,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -121,10 +152,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/en/colonial-rulebook-6-stages/index.html
+++ b/docs/content/media/en/colonial-rulebook-6-stages/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>The Colonial Rulebook: 6 Stages to Conquer — And Why It Still Echoes</title>
+  <title>The Colonial Rulebook: 6 Stages to Conquer — And Why It Still Echoes — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/colonial-rulebook-6-stages/">
-  <meta property="og:title" content="The Colonial Rulebook: 6 Stages to Conquer — And Why It Still Echoes">
+  <meta property="og:title" content="The Colonial Rulebook: 6 Stages to Conquer — And Why It Still Echoes — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/colonial-rulebook-6-stages/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="The Colonial Rulebook: 6 Stages to Conquer — And Why It Still Echoes — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/colonial-rulebook-6-stages/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/en/colonial-rulebook-6-stages/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -105,7 +136,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -124,10 +155,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/en/not-just-football-drama/index.html
+++ b/docs/content/media/en/not-just-football-drama/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Not Just Football ⚽🔥 — The Real Reason Sports Hook Us</title>
+  <title>Not Just Football ⚽🔥 — The Real Reason Sports Hook Us — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/not-just-football-drama/">
-  <meta property="og:title" content="Not Just Football ⚽🔥 — The Real Reason Sports Hook Us">
+  <meta property="og:title" content="Not Just Football ⚽🔥 — The Real Reason Sports Hook Us — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/not-just-football-drama/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Not Just Football ⚽🔥 — The Real Reason Sports Hook Us — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/en/not-just-football-drama/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/en/not-just-football-drama/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -102,7 +133,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -121,10 +152,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/content/media/mona-lisa-glitch-mode/index.html
+++ b/docs/content/media/mona-lisa-glitch-mode/index.html
@@ -1,25 +1,56 @@
 <!DOCTYPE html>
 
 
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos</title>
+  <title>Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos — Tamer Mansour</title>
 
   
   
   
   
+  
+    
+    
+      
+    
+  
+  
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/mona-lisa-glitch-mode/">
-  <meta property="og:title" content="Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos">
+  <meta property="og:title" content="Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos — Tamer Mansour">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/mona-lisa-glitch-mode/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Mona Lisa in Glitch Mode – 3 min 30 of AI Chaos — Tamer Mansour">
   
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/content/media/mona-lisa-glitch-mode/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/content/media/mona-lisa-glitch-mode/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="preconnect" href="https://cdn.midjourney.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.midjourney.com">
@@ -88,7 +119,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; 2025 Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -107,10 +138,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab.js"></script>
   <script defer src="/Tamer-Portfolio/js/iab-nav-fix.js"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/docs/gallery/index.html
+++ b/docs/gallery/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Gallery</title>
+  <title>Gallery — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="Curated AI visuals &amp; short reels from Midjourney (external sources).">
-  <meta property="og:title" content="Gallery">
+  <meta property="og:title" content="Gallery — Tamer Mansour">
   <meta property="og:description" content="Curated AI visuals &amp; short reels from Midjourney (external sources).">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/gallery/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Gallery — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/gallery/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/gallery/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -482,7 +517,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Home</title>
+  <title>Home — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="AI, Identity &amp; Imagination — crafting futures with technology, grounded in history.">
-  <meta property="og:title" content="Home">
+  <meta property="og:title" content="Home — Tamer Mansour">
   <meta property="og:description" content="AI, Identity &amp; Imagination — crafting futures with technology, grounded in history.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Home — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -246,7 +281,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/media/index.html
+++ b/docs/media/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Media &amp; Reels</title>
+  <title>Media &amp; Reels — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="AI-generated films, reels, and visual poems by Tamer Mansour.">
-  <meta property="og:title" content="Media &amp; Reels">
+  <meta property="og:title" content="Media &amp; Reels — Tamer Mansour">
   <meta property="og:description" content="AI-generated films, reels, and visual poems by Tamer Mansour.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/media/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Media &amp; Reels — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/media/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/media/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -382,7 +417,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/music/index.html
+++ b/docs/music/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Music</title>
+  <title>Music — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="">
-  <meta property="og:title" content="Music">
+  <meta property="og:title" content="Music — Tamer Mansour">
   <meta property="og:description" content="">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/music/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Music — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/music/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/music/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -219,7 +254,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Projects</title>
+  <title>Projects — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="Selected projects across AI, media, and research.">
-  <meta property="og:title" content="Projects">
+  <meta property="og:title" content="Projects — Tamer Mansour">
   <meta property="og:description" content="Selected projects across AI, media, and research.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/projects/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Projects — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/projects/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/projects/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -141,7 +176,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -1,22 +1,53 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Research</title>
+  <title>Research — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="Interactive notebooks you can explore (NotebookLM).">
-  <meta property="og:title" content="Research">
+  <meta property="og:title" content="Research — Tamer Mansour">
   <meta property="og:description" content="Interactive notebooks you can explore (NotebookLM).">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/research/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Research — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/research/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/research/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -526,7 +557,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -137,154 +137,154 @@
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/about/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/about/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/category/يوميات-صناعة/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/contact/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/gallery/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/media/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/music/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/projects/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/research/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/tag/سير-العمل/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/category/Making-of/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/contact/</loc>
-      <lastmod>2025-12-15T20:38:31.870Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.738Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/gallery/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/media/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/music/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/ar/blog/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/projects/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/research/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.970Z</lastmod>
     </url>
     
   
@@ -295,14 +295,14 @@
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/blog/tag/ai-film/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.974Z</lastmod>
     </url>
     
   
     
     <url>
       <loc>https://tamermansour-ai.github.io/Tamer-Portfolio/training-consulting/</loc>
-      <lastmod>2025-12-15T20:38:32.106Z</lastmod>
+      <lastmod>2025-12-15T21:11:30.974Z</lastmod>
     </url>
     
   

--- a/docs/training-consulting/index.html
+++ b/docs/training-consulting/index.html
@@ -1,22 +1,57 @@
 <!doctype html>
+
+
+
+
+
+  
+
+
+  
+    
+  
+
 <html lang="en" >
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>Training &amp; Consulting</title>
+  <title>Training &amp; Consulting — Tamer Mansour</title>
   <meta name="theme-color" content="#5a6b2c">
 
   
+  
+  
+    
+    
+      
+    
+  
+  
+
+  
   <meta name="description" content="AI training and creative consulting for teams and creators.">
-  <meta property="og:title" content="Training &amp; Consulting">
+  <meta property="og:title" content="Training &amp; Consulting — Tamer Mansour">
   <meta property="og:description" content="AI training and creative consulting for teams and creators.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tamermansour-ai.github.io/Tamer-Portfolio/training-consulting/">
   <meta property="og:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://tamermansour-ai.github.io/Tamer-Portfolio/assets/img/og-cover.svg">
+  <meta name="twitter:title" content="Training &amp; Consulting — Tamer Mansour">
   <link rel="canonical" href="https://tamermansour-ai.github.io/Tamer-Portfolio/training-consulting/">
+
+  <link rel="alternate" hreflang="en" href="https://tamermansour-ai.github.io/Tamer-Portfolio/training-consulting/">
+  <link rel="alternate" hreflang="ar" href="https://tamermansour-ai.github.io/Tamer-Portfolio/ar/training-consulting/">
+  <link rel="alternate" hreflang="x-default" href="https://tamermansour-ai.github.io/Tamer-Portfolio/">
+
+  
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","inLanguage":"en","potentialAction":{"@type":"SearchAction","target":"https://tamermansour-ai.github.io/Tamer-Portfolio/search?q={search_term_string}","query-input":"required name=search_term_string"}}
+  </script>
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Person","name":"Tamer Mansour","url":"https://tamermansour-ai.github.io/Tamer-Portfolio","sameAs":["https://www.pinterest.com/TamerCreates/","https://www.tiktok.com/@ai_visionary_tm","https://www.youtube.com/@TamerAI-e5i"]}
+  </script>
 
   <link rel="stylesheet" href="/Tamer-Portfolio/styles.css">
 
@@ -331,7 +366,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© NaN Tamer Mansour</p>
+      <p class="foot-brand">© 2025 Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,5 +1,7 @@
 {
   "title": "Tamer Mansour — Portfolio",
+  "name": "Tamer Mansour",
   "url": "https://tamermansour-ai.github.io/Tamer-Portfolio",
-  "author": "Tamer Mansour"
+  "author": "Tamer Mansour",
+  "year": 2025
 }

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -3,6 +3,12 @@
 {% set __pageUrl = page.url or '/' %}
 {% set __isArabic = (__pageUrl | slice(0, 4)) == '/ar/' %}
 {% set __lang = lang or page.lang %}
+{% set __siteName = site.name or site.title or 'Tamer Mansour' %}
+{% if title %}
+  {% set __seoTitle = title + ' — ' + __siteName %}
+{% else %}
+  {% set __seoTitle = __siteName + ' — Portfolio' %}
+{% endif %}
 {% if not __lang %}
   {% if __isArabic %}
     {% set __lang = 'ar' %}
@@ -15,7 +21,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>{{ title }}</title>
+  <title>{{ __seoTitle }}</title>
 
   {# basic SEO #}
   {% if description %}<meta name="description" content="{{ description }}">{% endif %}
@@ -34,12 +40,13 @@
   {% endif %}
   {% set __og_image = site.url + '/assets/img/og-cover.svg' %}
   <link rel="canonical" href="{{ __canonical }}">
-  <meta property="og:title" content="{{ title }}">
+  <meta property="og:title" content="{{ __seoTitle }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ __canonical }}">
   <meta property="og:image" content="{{ __og_image }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ __og_image }}">
+  <meta name="twitter:title" content="{{ __seoTitle }}">
   {% if description %}<meta property="og:description" content="{{ description }}">{% endif %}
 
   <link rel="alternate" hreflang="en" href="{{ __enPath | absoluteUrl(__base) }}">
@@ -55,7 +62,7 @@
     {{ {
       "@context": "https://schema.org",
       "@type": "WebSite",
-      "name": site.title or site.name or 'Tamer Mansour',
+      "name": __siteName,
       "url": __base,
       "inLanguage": __lang,
       "potentialAction": {
@@ -69,7 +76,7 @@
     {{ {
       "@context": "https://schema.org",
       "@type": "Person",
-      "name": site.title or site.name or 'Tamer Mansour',
+      "name": __siteName,
       "url": __base,
       "sameAs": __socialLinks
     } | dump | safe }}
@@ -117,7 +124,7 @@
   </main>
 
   <footer>
-    <p>&copy; <span id="year"></span> Tamer Mansour</p>
+    <p>&copy; {{ site.year }} Tamer Mansour</p>
     <div class="social-icons">
       <a href="https://www.pinterest.com/TamerCreates/" target="_blank" aria-label="Pinterest">
         <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/pinterest.svg" alt="Pinterest icon">
@@ -136,10 +143,5 @@
   <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
   <script defer src="{{ '/js/iab.js' | url }}"></script>
   <script defer src="{{ '/js/iab-nav-fix.js' | url }}"></script>
-  <script>
-    // dynamic year to avoid NaN footer bug
-    const y = document.getElementById('year');
-    if (y) y.textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -2,6 +2,12 @@
 {% set __pageUrl = page.url or '/' %}
 {% set __isArabic = (__pageUrl | slice(0, 4)) == '/ar/' %}
 {% set __lang = lang or page.lang %}
+{% set __siteName = site.name or site.title or 'Tamer Mansour' %}
+{% if title %}
+  {% set __seoTitle = title + ' — ' + __siteName %}
+{% else %}
+  {% set __seoTitle = __siteName + ' — Portfolio' %}
+{% endif %}
 {% if not __lang %}
   {% if __isArabic %}
     {% set __lang = 'ar' %}
@@ -14,7 +20,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>{{ title or site.title }}</title>
+  <title>{{ __seoTitle }}</title>
   <meta name="theme-color" content="#5a6b2c">
 
   {% set __base = site.url or 'https://tamermansour-ai.github.io/Tamer-Portfolio' %}
@@ -34,13 +40,14 @@
 
   {% set desc = description or site.defaultDescription %}
   <meta name="description" content="{{ desc }}">
-  <meta property="og:title" content="{{ title or site.title }}">
+  <meta property="og:title" content="{{ __seoTitle }}">
   <meta property="og:description" content="{{ desc }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ __canonical }}">
   <meta property="og:image" content="{{ __og_image }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ __og_image }}">
+  <meta name="twitter:title" content="{{ __seoTitle }}">
   <link rel="canonical" href="{{ __canonical }}">
 
   <link rel="alternate" hreflang="en" href="{{ __enPath | absoluteUrl(__base) }}">
@@ -56,7 +63,7 @@
     {{ {
       "@context": "https://schema.org",
       "@type": "WebSite",
-      "name": site.title or site.name or 'Tamer Mansour — Portfolio',
+      "name": __siteName,
       "url": __base,
       "inLanguage": __lang,
       "potentialAction": {
@@ -70,7 +77,7 @@
     {{ {
       "@context": "https://schema.org",
       "@type": "Person",
-      "name": site.title or site.name or 'Tamer Mansour',
+      "name": __siteName,
       "url": __base,
       "sameAs": __socialLinks
     } | dump | safe }}
@@ -152,7 +159,7 @@
 
   <footer class="site-footer">
     <div class="container footer-grid">
-      <p class="foot-brand">© {{ now | date('yyyy') }} Tamer Mansour</p>
+      <p class="foot-brand">© {{ site.year }} Tamer Mansour</p>
       <div class="foot-social">
         <a href="https://www.pinterest.com/TamerCreates/" target="_blank" rel="noopener" aria-label="Pinterest">
           <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="#BD081C"><path d="M12 2a10 10 0 0 0-4 19.2c.06-.86.12-2.18.03-3.12l-1.1-4.68s-.28-.58-.28-1.44c0-1.35.78-2.36 1.75-2.36.83 0 1.22.62 1.22 1.36 0 .83-.53 2.07-.8 3.22-.23.97.49 1.76 1.44 1.76 1.72 0 3.04-1.81 3.04-4.42 0-2.31-1.66-3.93-4.04-3.93-2.75 0-4.37 2.06-4.37 4.19 0 .83.32 1.72.73 2.2.08.1.09.2.07.31l-.28 1.13c-.04.17-.14.2-.32.12-1.2-.56-1.95-2.3-1.95-3.71 0-3.01 2.19-5.78 6.31-5.78 3.31 0 5.89 2.36 5.89 5.51 0 3.29-2.07 5.94-4.94 5.94-0.96 0-1.86-.5-2.17-1.08l-.59 2.24c-.21.84-.78 1.9-1.17 2.55A10 10 0 1 0 12 2z"/></svg>


### PR DESCRIPTION
## Summary
- format page titles and social meta tags to use site branding with a portfolio fallback
- add site name/year data and apply it to schema markup and footer output
- regenerate built docs with the corrected titles and footer text

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941167847548322bb41328534e0a401)